### PR TITLE
Update execution phase for sample

### DIFF
--- a/examples/sentry-maven-plugin-example/pom.xml
+++ b/examples/sentry-maven-plugin-example/pom.xml
@@ -41,7 +41,7 @@
                 </configuration>
                 <executions>
                     <execution>
-                        <phase>install</phase>
+                        <phase>generate-resources</phase>
                         <goals>
                             <goal>uploadSourceBundle</goal>
                         </goals>


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->
Change what execution phase is configured for our plugin in the sample from `install` to `generate-resources`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When configuring for `install` phase the artifact (e.g. JAR) didn't include `sentry-debug-meta.properties` (have to run with `clean` to notice). Also our plugin wasn't run if e.g. `package` was executed.
See https://github.com/getsentry/sentry-docs/issues/7241

## :green_heart: How did you test it?
manually invoked `install` as well as `package`.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
