### PR TITLE
Windows Support for Maven Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add support for building on Windows
+
+### Fixes
+
+- Also use `url` and `authToken` for upload command
+
 ## 0.0.2
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Features
 
-- Add support for building on Windows
+- Add support for building on Windows ([#7](https://github.com/getsentry/sentry-maven-plugin/pull/7))
 
 ### Fixes
 
-- Also use `url` and `authToken` for upload command
+- Also use `url` and `authToken` for upload command ([#7](https://github.com/getsentry/sentry-maven-plugin/pull/7))
 
 ## 0.0.2
 

--- a/examples/sentry-maven-plugin-example/pom.xml
+++ b/examples/sentry-maven-plugin-example/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>io.sentry</groupId>
             <artifactId>sentry</artifactId>
-            <version>6.19.1-SNAPSHOT</version>
+            <version>6.21.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/examples/sentry-maven-plugin-example/pom.xml
+++ b/examples/sentry-maven-plugin-example/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>io.sentry</groupId>
             <artifactId>sentry</artifactId>
-            <version>6.21.0</version>
+            <version>6.24.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/io/sentry/UploadSourceBundleMojo.java
+++ b/src/main/java/io/sentry/UploadSourceBundleMojo.java
@@ -154,13 +154,8 @@ public class UploadSourceBundleMojo extends AbstractMojo {
     private void runSentryCli(String sentryCliCommand) throws MojoExecutionException {
         boolean isWindows = System.getProperty("os.name").toLowerCase().startsWith("windows");
 
-        String executable = "/bin/sh";
-        String cArg = "-c";
-
-        if(isWindows) {
-            executable = "cmd.exe";
-            cArg = "/c";
-        }
+        String executable = isWindows ? "cmd.exe" : "/bin/sh";
+        String cArg = isWindows ? "/c" : "-c";
 
         executeMojo(
             plugin(

--- a/src/main/java/io/sentry/UploadSourceBundleMojo.java
+++ b/src/main/java/io/sentry/UploadSourceBundleMojo.java
@@ -130,6 +130,13 @@ public class UploadSourceBundleMojo extends AbstractMojo {
             command.add("--log-level=debug");
         }
 
+        if (url != null) {
+            command.add("--url=" + url);
+        }
+        if (authToken != null) {
+            command.add("--auth-token=" + authToken);
+        }
+
         command.add("debug-files");
         command.add("upload");
         command.add("--type=jvm");

--- a/src/main/java/io/sentry/UploadSourceBundleMojo.java
+++ b/src/main/java/io/sentry/UploadSourceBundleMojo.java
@@ -162,7 +162,6 @@ public class UploadSourceBundleMojo extends AbstractMojo {
             cArg = "/c";
         }
 
-        // TODO probably won't work on windows
         executeMojo(
             plugin(
                 groupId("org.apache.maven.plugins"),

--- a/src/main/java/io/sentry/UploadSourceBundleMojo.java
+++ b/src/main/java/io/sentry/UploadSourceBundleMojo.java
@@ -13,13 +13,14 @@ import org.apache.maven.project.MavenProject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
 
@@ -144,6 +145,16 @@ public class UploadSourceBundleMojo extends AbstractMojo {
     }
 
     private void runSentryCli(String sentryCliCommand) throws MojoExecutionException {
+        boolean isWindows = System.getProperty("os.name").toLowerCase().startsWith("windows");
+
+        String executable = "/bin/sh";
+        String cArg = "-c";
+
+        if(isWindows) {
+            executable = "cmd.exe";
+            cArg = "/c";
+        }
+
         // TODO probably won't work on windows
         executeMojo(
             plugin(
@@ -156,9 +167,9 @@ public class UploadSourceBundleMojo extends AbstractMojo {
                 element(name("target"),
                     element(name("exec"),
                         attributes(
-                            attribute("executable", "/bin/sh")
+                            attribute("executable", executable)
                         ),
-                        element(name("arg"), attributes(attribute("value", "-c"))),
+                        element(name("arg"), attributes(attribute("value", cArg))),
                         element(name("arg"), attributes(attribute("value", sentryCliExecutablePath + " " + sentryCliCommand)))
                     )
                 )


### PR DESCRIPTION
## :scroll: Description
- Check if OS is Windows and adapt command for launching `SentryCli` accordingly
- Honor `url` and `authToken` parameters in `upload` command

## :bulb: Motivation and Context
Fixes #5 


## :green_heart: How did you test it?
- Built and ran on Windows and MacOS.
- Checked Issues on Sentry UI.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
