### PR TITLE
Download and Bundle sentry-cli with maven plugin

### DIFF
--- a/download-sentry-cli.sh
+++ b/download-sentry-cli.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+cd $(dirname "$0")
+
+props_file="sentry-cli.properties"
+
+function prop {
+  grep "$1" $2 | cut -d'=' -f2 | xargs
+}
+
+base_url="$(prop 'repo' $props_file)/releases/download/$(prop 'version' $props_file)"
+target_dir="src/main/resources/bin/"
+actual_props_file="$target_dir${props_file}"
+PLATFORMS="Darwin-universal Linux-i686 Linux-x86_64 Windows-i686"
+
+function shouldDownload {
+    if ! cmp -s "$props_file" "$actual_props_file"; then
+        echo "Props file differ, going to download cli"
+        return
+    fi
+
+    if test $(ls $target_dir | wc -l) -lt 5; then
+        echo "Sentry cli missing, going to download"
+        return
+    fi
+
+    echo "Sentry cli exists, not downloading"
+
+    false
+}
+
+if shouldDownload; then
+    rm -f $target_dir/sentry-cli-*
+    for plat in $PLATFORMS; do
+      suffix=''
+      if [[ $plat == *"Windows"* ]]; then
+        suffix='.exe'
+      fi
+      echo "${plat}"
+      download_url=$base_url//sentry-cli-${plat}${suffix}
+      fn="$target_dir/sentry-cli-${plat}${suffix}"
+      curl -SL --progress-bar "$download_url" -o "$fn"
+      chmod +x "$fn"
+      cp $props_file $target_dir/$props_file
+    done
+fi

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,27 @@
               <releaseProfiles>releases</releaseProfiles>
           </configuration>
         </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>3.1.0</version>
+            <executions>
+                <execution>
+                    <phase>generate-resources</phase>
+                    <goals>
+                        <goal>run</goal>
+                    </goals>
+                    <configuration>
+                        <target name="Sentry CLI Download">
+                            <exec executable="/bin/sh" failonerror="true">
+                                <arg value="-c"/>
+                                <arg value="./download-sentry-cli.sh"/>
+                            </exec>
+                        </target>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
       </plugins>
   </build>
   <dependencies>

--- a/sentry-cli.properties
+++ b/sentry-cli.properties
@@ -1,0 +1,2 @@
+version = 2.19.1
+repo = https://github.com/getsentry/sentry-cli

--- a/src/main/java/io/sentry/SentryCliProvider.java
+++ b/src/main/java/io/sentry/SentryCliProvider.java
@@ -1,0 +1,107 @@
+package io.sentry;
+
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Locale;
+
+/*
+ * Helper class to find sentry-cli
+ * Ported from sentry-android-gradle-plugin
+ */
+class SentryCliProvider {
+
+    private static Logger logger = LoggerFactory.getLogger(SentryCliProvider.class);
+
+    protected static String getCliPath(MavenProject mavenProject, String cliPathParameter) {
+
+        if(cliPathParameter != null && !cliPathParameter.isBlank()) {
+            return cliPathParameter;
+        }
+
+        String cliSuffix = getCliSuffix();
+
+        if(cliSuffix != null && !cliSuffix.isBlank()) {
+            String resourcePath = "/bin/sentry-cli-" + cliSuffix;
+            String cliAbsolutePath = searchCliInResources(resourcePath);
+
+            if(cliAbsolutePath != null) {
+                logger.info("Cli found in " + cliAbsolutePath);
+                return cliAbsolutePath;
+            }
+
+            String cliTempPath = loadCliFromResourcesToTemp(resourcePath);
+
+            if(cliTempPath != null) {
+                logger.info("Cli found in " + cliTempPath);
+                return cliTempPath;
+            }
+
+        }
+
+        return "sentry-cli";
+    }
+
+    private static String getCliSuffix() {
+        String osName = System.getProperty("os.name").toLowerCase(Locale.ROOT);
+        String osArch = System.getProperty("os.arch");
+
+        if(osName.contains("mac")) {
+            return "Darwin-universal";
+        }
+
+        if(osName.contains("linux")) {
+            return osArch.equals("amd64") ? "Linux-x86_64" : "Linux-" + osArch;
+        }
+
+        if(osName.contains("win")) {
+            return "Windows-i686.exe";
+        }
+
+        return null;
+    }
+
+    private static String searchCliInResources(String resourcePath) {
+        URL resourceUrl = SentryCliProvider.class.getResource(resourcePath);
+
+        if(resourceUrl != null) {
+            File resourceFile = new File(resourceUrl.getFile());
+            if(resourceFile.exists()) {
+                return resourceFile.getAbsolutePath();
+            }
+        }
+        return null;
+    }
+
+    private static String loadCliFromResourcesToTemp(String resourcePath) {
+
+        try (InputStream inputStream = SentryCliProvider.class.getResourceAsStream(resourcePath)) {
+            File tempFile = File.createTempFile(".sentry-cli", ".exe");
+            tempFile.deleteOnExit();
+            tempFile.setExecutable(true);
+
+            FileOutputStream outputStream = new FileOutputStream(tempFile);
+
+            if(inputStream != null) {
+                inputStream.transferTo(outputStream);
+                outputStream.close();
+                return tempFile.getAbsolutePath();
+            } else {
+                return null;
+            }
+
+        } catch (IOException e) {
+            logger.error(e.getMessage(), e);
+            return null;
+        }
+
+    }
+
+}

--- a/src/main/java/io/sentry/UploadSourceBundleMojo.java
+++ b/src/main/java/io/sentry/UploadSourceBundleMojo.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import static io.sentry.SentryCliProvider.getCliPath;
 import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
 
 @Mojo(name = "uploadSourceBundle", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
@@ -171,7 +172,7 @@ public class UploadSourceBundleMojo extends AbstractMojo {
                             attribute("executable", executable)
                         ),
                         element(name("arg"), attributes(attribute("value", cArg))),
-                        element(name("arg"), attributes(attribute("value", sentryCliExecutablePath + " " + sentryCliCommand)))
+                        element(name("arg"), attributes(attribute("value", getCliPath(mavenProject, sentryCliExecutablePath) + " " + sentryCliCommand)))
                     )
                 )
             ),

--- a/src/main/resources/bin/.gitignore
+++ b/src/main/resources/bin/.gitignore
@@ -1,0 +1,2 @@
+sentry-cli-*
+sentry-cli.properties


### PR DESCRIPTION
Download and Bundle sentry-cli with maven plugin

## :scroll: Description
Download sentry-cli when building the plugin.
Execute the bundled sentry-cli executable if none is supplied by the user in the plug-in config


## :bulb: Motivation and Context
Fixes #2 


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
