### PR TITLE
Add `debug` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Report dependencies ([#22](https://github.com/getsentry/sentry-maven-plugin/pull/22))
 - Send telemetry data for plugin usage ([#28](https://github.com/getsentry/sentry-maven-plugin/pull/28))
   - This will collect errors and timings of the plugin and its tasks (anonymized, except the sentry org id), so we can better understand how the plugin is performing. If you wish to opt-out of this behavior, set `<skipTelemetry>true</skipTelemetry>` in the sentry plugin configuration block.
+- Add `debug` flag ([#38](https://github.com/getsentry/sentry-maven-plugin/pull/38))
 
 ### Dependencies
 

--- a/examples/sentry-maven-plugin-example/pom.xml
+++ b/examples/sentry-maven-plugin-example/pom.xml
@@ -21,6 +21,8 @@
                 <version>1.0-SNAPSHOT</version>
                 <extensions>true</extensions>
                 <configuration>
+                    <!-- for showing debug output -->
+                    <debug>false</debug>
                     <!-- for showing output of sentry-cli -->
                     <debugSentryCli>true</debugSentryCli>
 

--- a/src/main/java/io/sentry/config/ConfigParser.java
+++ b/src/main/java/io/sentry/config/ConfigParser.java
@@ -17,6 +17,7 @@ public class ConfigParser {
   private static final @NotNull String SKIP_REPORT_DEPENDENCIES_FLAG = "skipReportDependencies";
   private static final @NotNull String SKIP_SOURCE_BUNDLE_FLAG = "skipSourceBundle";
   private static final @NotNull String DEBUG_SENTRY_CLI_FLAG = "debugSentryCli";
+  private static final @NotNull String DEBUG_FLAG = "debug";
   private static final @NotNull String ORG_OPTION = "org";
   private static final @NotNull String PROJECT_OPTION = "project";
   private static final @NotNull String URL_OPTION = "url";
@@ -64,6 +65,10 @@ public class ConfigParser {
       pluginConfig.setDebugSentryCli(
           dom.getChild(DEBUG_SENTRY_CLI_FLAG) != null
               && Boolean.parseBoolean(dom.getChild(DEBUG_SENTRY_CLI_FLAG).getValue()));
+
+      pluginConfig.setDebug(
+          dom.getChild(DEBUG_FLAG) != null
+              && Boolean.parseBoolean(dom.getChild(DEBUG_FLAG).getValue()));
 
       pluginConfig.setOrg(
           dom.getChild(ORG_OPTION) == null ? null : dom.getChild(ORG_OPTION).getValue());

--- a/src/main/java/io/sentry/config/PluginConfig.java
+++ b/src/main/java/io/sentry/config/PluginConfig.java
@@ -38,7 +38,7 @@ public class PluginConfig {
   }
 
   public boolean isDebugSentryCli() {
-    return debugSentryCli;
+    return debugSentryCli || debug;
   }
 
   public void setDebug(final boolean debug) {

--- a/src/main/java/io/sentry/config/PluginConfig.java
+++ b/src/main/java/io/sentry/config/PluginConfig.java
@@ -16,6 +16,8 @@ public class PluginConfig {
   public static final @NotNull String DEFAULT_SKIP_TELEMETRY_STRING = "false";
   public static final boolean DEFAULT_DEBUG_SENTRY_CLI = false;
   public static final @NotNull String DEFAULT_DEBUG_SENTRY_CLI_STRING = "false";
+  public static final boolean DEFAULT_DEBUG = false;
+  public static final @NotNull String DEFAULT_DEBUG_STRING = "false";
 
   private boolean skip = DEFAULT_SKIP;
   private boolean skipAutoInstall = DEFAULT_SKIP_AUTO_INSTALL;
@@ -23,6 +25,7 @@ public class PluginConfig {
   private boolean skipReportDependencies = DEFAULT_SKIP_REPORT_DEPENDENCIES;
   private boolean skipSourceBundle = DEFAULT_SKIP_SOURCE_BUNDLE;
   private boolean debugSentryCli = DEFAULT_DEBUG_SENTRY_CLI;
+  private boolean debug = DEFAULT_DEBUG;
 
   private @Nullable String org;
   private @Nullable String project;
@@ -36,6 +39,14 @@ public class PluginConfig {
 
   public boolean isDebugSentryCli() {
     return debugSentryCli;
+  }
+
+  public void setDebug(final boolean debug) {
+    this.debug = debug;
+  }
+
+  public boolean isDebug() {
+    return debug;
   }
 
   public void setSentryCliExecutablePath(final @Nullable String sentryCliExecutablePath) {

--- a/src/main/java/io/sentry/telemetry/SentryTelemetryService.java
+++ b/src/main/java/io/sentry/telemetry/SentryTelemetryService.java
@@ -85,7 +85,7 @@ public class SentryTelemetryService {
         Sentry.init(
             (options) -> {
               options.setDsn(SENTRY_SAAS_DSN);
-              options.setDebug(true);
+              options.setDebug(pluginConfig.isDebug());
               options.setEnablePrettySerializationOutput(false);
               options.setEnvironment("JVM");
               options.setSendModules(false);


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
A new configuration option `<debug>` which can be set to true to show debug output.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows users to control whether they want to see Sentry output of the plugin (i.e. telemetry).

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
