### PR TITLE
Add `aarch64` sentry-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Report dependencies ([#22](https://github.com/getsentry/sentry-maven-plugin/pull/22))
 - Send telemetry data for plugin usage ([#28](https://github.com/getsentry/sentry-maven-plugin/pull/28))
   - This will collect errors and timings of the plugin and its tasks (anonymized, except the sentry org id), so we can better understand how the plugin is performing. If you wish to opt-out of this behavior, set `<skipTelemetry>true</skipTelemetry>` in the sentry plugin configuration block.
+- Add `aarch64` sentry-cli ([#39](https://github.com/getsentry/sentry-maven-plugin/pull/39))
+  - This is used when the build is executed inside a docker container on an Apple silicon chip (e.g. M1)
 
 ### Dependencies
 

--- a/download-sentry-cli.sh
+++ b/download-sentry-cli.sh
@@ -10,7 +10,7 @@ function prop {
 base_url="$(prop 'repo' $props_file)/releases/download/$(prop 'version' $props_file)"
 target_dir="src/main/resources/bin/"
 actual_props_file="$target_dir${props_file}"
-PLATFORMS="Darwin-universal Linux-i686 Linux-x86_64 Windows-i686"
+PLATFORMS="Darwin-universal Linux-i686 Linux-x86_64 Windows-i686 Linux-aarch64"
 
 function shouldDownload {
     if ! cmp -s "$props_file" "$actual_props_file"; then

--- a/download-sentry-cli.sh
+++ b/download-sentry-cli.sh
@@ -10,7 +10,7 @@ function prop {
 base_url="$(prop 'repo' $props_file)/releases/download/$(prop 'version' $props_file)"
 target_dir="src/main/resources/bin/"
 actual_props_file="$target_dir${props_file}"
-PLATFORMS="Darwin-universal Linux-i686 Linux-x86_64 Windows-i686 Linux-aarch64"
+PLATFORMS="Darwin-universal Linux-i686 Linux-x86_64 Linux-aarch64 Windows-i686"
 
 function shouldDownload {
     if ! cmp -s "$props_file" "$actual_props_file"; then

--- a/src/main/java/io/sentry/SentryCliProvider.java
+++ b/src/main/java/io/sentry/SentryCliProvider.java
@@ -34,6 +34,7 @@ public class SentryCliProvider {
     final @Nullable String cliSuffix = getCliSuffix();
 
     if (cliSuffix != null && !cliSuffix.isBlank()) {
+      logger.info("Looking for CLI with suffix " + cliSuffix);
       final @NotNull String resourcePath = "/bin/sentry-cli-" + cliSuffix;
       final @Nullable String cliAbsolutePath = searchCliInResources(resourcePath);
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Add `aarch64` sentry-cli platform as that's what is reported by `uname -m` inside docker containers running on an Apple silicon chip (e.g. M1, M2, ...).

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #34 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
