### PR TITLE
Disable source upload via `SENTRY_SKIP_SOURCE_UPLOAD` env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Disable source upload via `SENTRY_SKIP_SOURCE_UPLOAD` environment variable ([#65](https://github.com/getsentry/sentry-maven-plugin/pull/65))
+
 ### Dependencies
 
 - Bump Sentry SDK from v7.3.0 to v7.6.0 ([#55](https://github.com/getsentry/sentry-maven-plugin/pull/55), [#56](https://github.com/getsentry/sentry-maven-plugin/pull/56), [#59](https://github.com/getsentry/sentry-maven-plugin/pull/59))

--- a/src/main/java/io/sentry/UploadSourceBundleMojo.java
+++ b/src/main/java/io/sentry/UploadSourceBundleMojo.java
@@ -71,7 +71,8 @@ public class UploadSourceBundleMojo extends AbstractMojo {
 
   @Override
   public void execute() throws MojoExecutionException {
-    if (skip || skipSourceBundle) {
+    final @Nullable String sentrySkipSourceUpload = System.getenv("SENTRY_SKIP_SOURCE_UPLOAD");
+    if (skip || skipSourceBundle || "true".equalsIgnoreCase(sentrySkipSourceUpload)) {
       logger.info("Upload Source Bundle skipped");
       return;
     }


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Allow disabling source upload via `SENTRY_SKIP_SOURCE_UPLOAD` env var.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getsentry/sentry-maven-plugin/issues/60

Source upload requires an auth token and fails the build without a valid one. This allows disabling source upload without changing `pom.xml`

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
