### PR TITLE
all-repos: update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           ./mvnw clean package assembly:single
 
       - name: Archive artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ github.sha }}
           path: |


### PR DESCRIPTION
#skip-changelog

Committed via https://github.com/asottile/all-repos