### PR TITLE
More lenient handling of empty Maven modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Features
+
+- More lenient handling of empty Maven modules ([#103](https://github.com/getsentry/sentry-maven-plugin/pull/103))
+  - The Maven plugin now ignores Maven modules with empty source roots and instead of failing the build simply prints a log message
+  - This allows the plugin to be configured in the root POM even if it does not have sources
+
 ### Dependencies
 
 - Bump Sentry SDK from v7.8.0 to v7.16.0 ([#78](https://github.com/getsentry/sentry-maven-plugin/pull/78), [#86](https://github.com/getsentry/sentry-maven-plugin/pull/86), [#97](https://github.com/getsentry/sentry-maven-plugin/pull/97), [#99](https://github.com/getsentry/sentry-maven-plugin/pull/99))

--- a/src/main/java/io/sentry/UploadSourceBundleMojo.java
+++ b/src/main/java/io/sentry/UploadSourceBundleMojo.java
@@ -104,8 +104,8 @@ public class UploadSourceBundleMojo extends AbstractMojo {
 
       final @NotNull List<String> bundleSourcesCommand = new ArrayList<>();
       final @NotNull List<String> sourceRoots = mavenProject.getCompileSourceRoots();
-      final @Nullable String sourceRoot = sourceRoots != null && sourceRoots.size() > 0
-          ? sourceRoots.get(0) : null;
+      final @Nullable String sourceRoot =
+          sourceRoots != null && !sourceRoots.isEmpty() ? sourceRoots.get(0) : null;
 
       if (sourceRoot != null && new File(sourceRoot).exists()) {
         if (sourceRoots.size() > 1) {

--- a/src/main/java/io/sentry/UploadSourceBundleMojo.java
+++ b/src/main/java/io/sentry/UploadSourceBundleMojo.java
@@ -104,9 +104,10 @@ public class UploadSourceBundleMojo extends AbstractMojo {
 
       final @NotNull List<String> bundleSourcesCommand = new ArrayList<>();
       final @NotNull List<String> sourceRoots = mavenProject.getCompileSourceRoots();
+      final @Nullable String sourceRoot = sourceRoots != null && sourceRoots.size() > 0
+          ? sourceRoots.get(0) : null;
 
-      if (sourceRoots != null && sourceRoots.size() > 0) {
-        final @Nullable String sourceRoot = sourceRoots.get(0);
+      if (sourceRoot != null && new File(sourceRoot).exists()) {
         if (sourceRoots.size() > 1) {
           logger.warn("There's more than one source root, using {}", sourceRoot);
         }
@@ -148,7 +149,7 @@ public class UploadSourceBundleMojo extends AbstractMojo {
 
         cliRunner.runSentryCli(String.join(" ", bundleSourcesCommand), true);
       } else {
-        throw new MojoExecutionException("Unable to find source root");
+        logger.info("Skipping module, as it doesn't have any source roots");
       }
     } catch (Throwable t) {
       SentryTelemetryService.getInstance().captureError(t, "bundleSources");


### PR DESCRIPTION
## :scroll: Description
Maven allows for empty modules to exist, e.g. you can have a Maven module without any Java sources in it.
This is especially common in multi-module projects, where the root module has no sources at all, but only contains children modules; thus the root module does not contain the `src/main/java` directory.

#### Our use case
Maven supports inheritance of plugins, that is in multi-module project you can declare a plugin (using `<plugins><plugin> .... </plugins>`) in the root `pom.xml` and then this definition will be inherited by all children modules. This would allow us to declare the Sentry plugin only once in the root `pom.xml`, and have it be inherited in all children.

However, this does not work, because our root `pom.xml` is an empty module without Java sources, and currently Sentry plugin fails in these circumstances.

## :bulb: Motivation and Context

Allow more convenient use of Sentry plugin in multi-module Maven deployments.


## :green_heart: How did you test it?

🔧 Manually tested -> works as expected with a multi-module projects

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] No breaking changes


## :crystal_ball: Next steps
