### PR TITLE
Detect SDK dependency version mismatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Detect SDK dependency version mismatches ([#126](https://github.com/getsentry/sentry-maven-plugin/pull/126))
+  - The new `validateSdkDependencyVersions` goal verifies that all of the Sentry SDK dependencies included in your `pom.xml` have consistent versions
+  - We recommend enabling this goal by adding 
+    ```xml
+    <executions>
+        <execution>
+            <goals>
+                <goal>validateSdkDependencyVersions</goal>
+            </goals>
+        </execution>
+    </executions>
+    ```
+    within your `plugin` tag for `io.sentry:sentry-maven-plugin`
+  - The build will fail in the `validate` lifecycle phase if a version mismatch is detected
+  - You can opt out of this check by disabling the `validateSdkDependencyVersions` goal or by adding
+    ```xml
+    <configuration>
+        <skipValidateSdkDependencyVersions>true</skipValidateSdkDependencyVersions>
+    </configuration>
+    ```
+    within your `plugin` tag for `io.sentry:sentry-maven-plugin`.
+    This is not recommended, as using mismatched versions of the Sentry dependencies can introduce build time or run time failures and crashes.
+
 ## 0.3.0
 
 ### Dependencies

--- a/examples/sentry-maven-plugin-example/pom.xml
+++ b/examples/sentry-maven-plugin-example/pom.xml
@@ -47,12 +47,14 @@
                     <skipSourceBundle>false</skipSourceBundle>
                     <skipAutoInstall>false</skipAutoInstall>
                     <skipTelemetry>false</skipTelemetry>
+                    <skipValidateSdkDependencyVersions>false</skipValidateSdkDependencyVersions>
                 </configuration>
                 <executions>
                     <execution>
                         <goals>
                             <goal>uploadSourceBundle</goal>
                             <goal>reportDependencies</goal>
+                            <goal>validateSdkDependencyVersions</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/src/main/java/io/sentry/Constants.java
+++ b/src/main/java/io/sentry/Constants.java
@@ -1,0 +1,9 @@
+package io.sentry;
+
+import org.jetbrains.annotations.NotNull;
+
+public class Constants {
+  public static final @NotNull String SENTRY_GROUP_ID = "io.sentry";
+  public static final @NotNull String SENTRY_SDK_ARTIFACT_ID = "sentry";
+  public static final @NotNull String SENTRY_PLUGIN_ARTIFACT_ID = "sentry-maven-plugin";
+}

--- a/src/main/java/io/sentry/SentryInstallerLifecycleParticipant.java
+++ b/src/main/java/io/sentry/SentryInstallerLifecycleParticipant.java
@@ -1,6 +1,6 @@
 package io.sentry;
 
-import static io.sentry.autoinstall.Constants.SENTRY_GROUP_ID;
+import static io.sentry.Constants.SENTRY_GROUP_ID;
 import static io.sentry.autoinstall.graphql.Graphql22InstallStrategy.SENTRY_GRAPHQL_22_ID;
 import static io.sentry.autoinstall.graphql.GraphqlInstallStrategy.SENTRY_GRAPHQL_ID;
 import static io.sentry.autoinstall.jdbc.JdbcInstallStrategy.SENTRY_JDBC_ID;

--- a/src/main/java/io/sentry/ValidateSdkDependencyVersionsMojo.java
+++ b/src/main/java/io/sentry/ValidateSdkDependencyVersionsMojo.java
@@ -1,0 +1,129 @@
+package io.sentry;
+
+import static io.sentry.Constants.SENTRY_GROUP_ID;
+import static io.sentry.Constants.SENTRY_PLUGIN_ARTIFACT_ID;
+import static io.sentry.Constants.SENTRY_SDK_ARTIFACT_ID;
+import static io.sentry.config.PluginConfig.DEFAULT_SKIP_STRING;
+import static io.sentry.config.PluginConfig.DEFAULT_SKIP_VALIDATE_SDK_DEPENDENCY_VERSIONS_STRING;
+
+import io.sentry.telemetry.SentryTelemetryService;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.DependencyResolutionException;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.artifact.Artifact;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Mojo(name = "validateSdkDependencyVersions", defaultPhase = LifecyclePhase.VALIDATE)
+public class ValidateSdkDependencyVersionsMojo extends AbstractMojo {
+
+  @Parameter(defaultValue = DEFAULT_SKIP_STRING)
+  private boolean skip;
+
+  @Parameter(defaultValue = DEFAULT_SKIP_VALIDATE_SDK_DEPENDENCY_VERSIONS_STRING)
+  private boolean skipValidateSdkDependencyVersions;
+
+  private static final @NotNull Logger logger =
+      LoggerFactory.getLogger(ValidateSdkDependencyVersionsMojo.class);
+
+  private static final String ERROR_MESSAGE = "Detected a mismatch in Sentry dependency versions.";
+  private static final String RESOLUTION_MESSAGE =
+      "Please remove any dependencies in the "
+          + SENTRY_GROUP_ID
+          + " group from your `pom.xml`, or ensure that all of them have the same version.";
+  private static final String ESCAPE_HATCH_MESSAGE =
+      "You can disable this check by setting `<skipValidateSdkDependencyVersions>true</skipValidateSdkDependencyVersions>` in your configuration for "
+          + SENTRY_GROUP_ID
+          + ":"
+          + SENTRY_PLUGIN_ARTIFACT_ID
+          + ".";
+
+  @SuppressWarnings("NullAway")
+  @Parameter(defaultValue = "${project}", readonly = true)
+  private @NotNull MavenProject mavenProject;
+
+  @SuppressWarnings("NullAway")
+  @Parameter(defaultValue = "${session}", readonly = true)
+  private @NotNull MavenSession mavenSession;
+
+  @Inject protected @NotNull ArtifactResolver artifactResolver;
+
+  @Override
+  public void execute() throws MojoExecutionException {
+    if (skip || skipValidateSdkDependencyVersions) {
+      logger.info("Skipping Sentry SDK dependency versions validation.");
+      return;
+    }
+    logger.info("Validating Sentry SDK dependency versions.");
+    final @Nullable ISpan span =
+        SentryTelemetryService.getInstance().startTask("validateSdkDependencyVersions");
+
+    try {
+      validateSdkDependencyVersions();
+    } catch (MojoExecutionException e) {
+      throw e;
+    } catch (DependencyResolutionException e) {
+      SentryTelemetryService.getInstance().captureError(e, "validateSdkDependencyVersions");
+      throw new RuntimeException(e);
+    } catch (Throwable t) {
+      SentryTelemetryService.getInstance().captureError(t, "validateSdkDependencyVersions");
+      throw t;
+    } finally {
+      SentryTelemetryService.getInstance().endTask(span);
+    }
+  }
+
+  private void validateSdkDependencyVersions()
+      throws MojoExecutionException, DependencyResolutionException {
+
+    Map<String, List<Artifact>> versionToArtifacts = new HashMap<>();
+    Set<Artifact> dependencies =
+        new HashSet<>(artifactResolver.resolveArtifactsForProject(mavenProject, mavenSession));
+    for (Artifact artifact : dependencies) {
+      if (!artifact.getGroupId().equals(SENTRY_GROUP_ID)) {
+        continue;
+      }
+      if (artifact.getArtifactId().equals(SENTRY_SDK_ARTIFACT_ID)
+          || artifact.getArtifactId().equals(SENTRY_PLUGIN_ARTIFACT_ID)) {
+        continue;
+      }
+      versionToArtifacts
+          .computeIfAbsent(artifact.getVersion(), v -> new ArrayList<>())
+          .add(artifact);
+    }
+
+    if (versionToArtifacts.size() > 1) {
+      StringBuilder exceptionMessage = new StringBuilder(ERROR_MESSAGE).append('\n');
+      versionToArtifacts.forEach(
+          (version, artifacts) ->
+              exceptionMessage.append(
+                  String.format(
+                      "Version %s required for: %s\n",
+                      version,
+                      artifacts.stream()
+                          .map((artifact) -> artifact.getGroupId() + ":" + artifact.getArtifactId())
+                          .collect(Collectors.joining(", ")))));
+      exceptionMessage.append(RESOLUTION_MESSAGE).append("\n\n");
+      exceptionMessage.append(ESCAPE_HATCH_MESSAGE);
+      logger.error("Found inconsistency in Sentry SDK dependency versions.");
+      throw new MojoExecutionException(exceptionMessage.toString());
+    }
+
+    logger.info("Sentry SDK dependency versions are all consistent.");
+  }
+}

--- a/src/main/java/io/sentry/ValidateSdkDependencyVersionsMojo.java
+++ b/src/main/java/io/sentry/ValidateSdkDependencyVersionsMojo.java
@@ -43,7 +43,7 @@ public class ValidateSdkDependencyVersionsMojo extends AbstractMojo {
   private static final String ERROR_MESSAGE =
       "Detected inconsistency in Sentry dependency versions.";
   private static final String RESOLUTION_MESSAGE =
-      "Please remove any dependencies in the "
+      "Please remove any explicit dependencies in the "
           + SENTRY_GROUP_ID
           + " group from your `pom.xml`, or ensure that all of them are present with the same version.";
   private static final String ESCAPE_HATCH_MESSAGE =

--- a/src/main/java/io/sentry/ValidateSdkDependencyVersionsMojo.java
+++ b/src/main/java/io/sentry/ValidateSdkDependencyVersionsMojo.java
@@ -2,7 +2,6 @@ package io.sentry;
 
 import static io.sentry.Constants.SENTRY_GROUP_ID;
 import static io.sentry.Constants.SENTRY_PLUGIN_ARTIFACT_ID;
-import static io.sentry.Constants.SENTRY_SDK_ARTIFACT_ID;
 import static io.sentry.config.PluginConfig.DEFAULT_SKIP_STRING;
 import static io.sentry.config.PluginConfig.DEFAULT_SKIP_VALIDATE_SDK_DEPENDENCY_VERSIONS_STRING;
 
@@ -41,17 +40,18 @@ public class ValidateSdkDependencyVersionsMojo extends AbstractMojo {
   private static final @NotNull Logger logger =
       LoggerFactory.getLogger(ValidateSdkDependencyVersionsMojo.class);
 
-  private static final String ERROR_MESSAGE = "Detected a mismatch in Sentry dependency versions.";
+  private static final String ERROR_MESSAGE =
+      "Detected inconsistency in Sentry dependency versions.";
   private static final String RESOLUTION_MESSAGE =
       "Please remove any dependencies in the "
           + SENTRY_GROUP_ID
-          + " group from your `pom.xml`, or ensure that all of them have the same version.";
+          + " group from your `pom.xml`, or ensure that all of them are present with the same version.";
   private static final String ESCAPE_HATCH_MESSAGE =
       "You can disable this check by setting `<skipValidateSdkDependencyVersions>true</skipValidateSdkDependencyVersions>` in your configuration for "
           + SENTRY_GROUP_ID
           + ":"
           + SENTRY_PLUGIN_ARTIFACT_ID
-          + ".";
+          + ".\nThis is not recommended, as mismatched dependency versions could lead to build time or run time failures and crashes.";
 
   @SuppressWarnings("NullAway")
   @Parameter(defaultValue = "${project}", readonly = true)
@@ -98,8 +98,7 @@ public class ValidateSdkDependencyVersionsMojo extends AbstractMojo {
       if (!artifact.getGroupId().equals(SENTRY_GROUP_ID)) {
         continue;
       }
-      if (artifact.getArtifactId().equals(SENTRY_SDK_ARTIFACT_ID)
-          || artifact.getArtifactId().equals(SENTRY_PLUGIN_ARTIFACT_ID)) {
+      if (artifact.getArtifactId().equals(SENTRY_PLUGIN_ARTIFACT_ID)) {
         continue;
       }
       versionToArtifacts

--- a/src/main/java/io/sentry/autoinstall/AbstractIntegrationInstaller.java
+++ b/src/main/java/io/sentry/autoinstall/AbstractIntegrationInstaller.java
@@ -1,6 +1,6 @@
 package io.sentry.autoinstall;
 
-import static io.sentry.autoinstall.Constants.SENTRY_GROUP_ID;
+import static io.sentry.Constants.SENTRY_GROUP_ID;
 
 import io.sentry.semver.Version;
 import java.util.List;

--- a/src/main/java/io/sentry/autoinstall/Constants.java
+++ b/src/main/java/io/sentry/autoinstall/Constants.java
@@ -1,6 +1,0 @@
-package io.sentry.autoinstall;
-
-public class Constants {
-  public static final String SENTRY_GROUP_ID = "io.sentry";
-  public static final String SENTRY_ARTIFACT_ID = "sentry";
-}

--- a/src/main/java/io/sentry/autoinstall/SentryInstaller.java
+++ b/src/main/java/io/sentry/autoinstall/SentryInstaller.java
@@ -1,7 +1,7 @@
 package io.sentry.autoinstall;
 
-import static io.sentry.autoinstall.Constants.SENTRY_ARTIFACT_ID;
-import static io.sentry.autoinstall.Constants.SENTRY_GROUP_ID;
+import static io.sentry.Constants.SENTRY_GROUP_ID;
+import static io.sentry.Constants.SENTRY_SDK_ARTIFACT_ID;
 
 import io.sentry.autoinstall.util.SdkVersionInfo;
 import java.util.List;
@@ -32,7 +32,7 @@ public class SentryInstaller {
             .filter(
                 (dep) ->
                     dep.getGroupId().equals(SENTRY_GROUP_ID)
-                        && dep.getArtifactId().equals(SENTRY_ARTIFACT_ID))
+                        && dep.getArtifactId().equals(SENTRY_SDK_ARTIFACT_ID))
             .findFirst()
             .orElse(null);
 
@@ -50,7 +50,7 @@ public class SentryInstaller {
       logger.info("Installing Sentry with version " + sentryVersion);
       final @NotNull Dependency newDep = new Dependency();
       newDep.setGroupId(SENTRY_GROUP_ID);
-      newDep.setArtifactId(SENTRY_ARTIFACT_ID);
+      newDep.setArtifactId(SENTRY_SDK_ARTIFACT_ID);
       newDep.setVersion(sentryVersion);
 
       dependencyList.add(newDep);

--- a/src/main/java/io/sentry/config/ConfigParser.java
+++ b/src/main/java/io/sentry/config/ConfigParser.java
@@ -1,6 +1,7 @@
 package io.sentry.config;
 
-import static io.sentry.autoinstall.Constants.SENTRY_GROUP_ID;
+import static io.sentry.Constants.SENTRY_GROUP_ID;
+import static io.sentry.Constants.SENTRY_PLUGIN_ARTIFACT_ID;
 
 import org.apache.maven.model.Plugin;
 import org.apache.maven.project.MavenProject;
@@ -10,12 +11,13 @@ import org.jetbrains.annotations.Nullable;
 
 public class ConfigParser {
 
-  private static final @NotNull String SENTRY_PLUGIN_ARTIFACT = "sentry-maven-plugin";
   private static final @NotNull String SKIP_ALL_FLAG = "skip";
   private static final @NotNull String SKIP_AUTO_INSTALL_FLAG = "skipAutoInstall";
   private static final @NotNull String SKIP_TELEMETRY_FLAG = "skipTelemetry";
   private static final @NotNull String SKIP_REPORT_DEPENDENCIES_FLAG = "skipReportDependencies";
   private static final @NotNull String SKIP_SOURCE_BUNDLE_FLAG = "skipSourceBundle";
+  private static final @NotNull String SKIP_VALIDATE_SDK_DEPENDENCY_VERSIONS_OPTION =
+      "skipValidateSdkDependencyVersions";
   private static final @NotNull String DEBUG_SENTRY_CLI_FLAG = "debugSentryCli";
   private static final @NotNull String DEBUG_FLAG = "debug";
   private static final @NotNull String ORG_OPTION = "org";
@@ -30,7 +32,7 @@ public class ConfigParser {
             .filter(
                 (plugin) ->
                     plugin.getGroupId().equals(SENTRY_GROUP_ID)
-                        && plugin.getArtifactId().equals(SENTRY_PLUGIN_ARTIFACT))
+                        && plugin.getArtifactId().equals(SENTRY_PLUGIN_ARTIFACT_ID))
             .findFirst()
             .orElse(null);
 
@@ -83,6 +85,11 @@ public class ConfigParser {
           dom.getChild(AUTH_TOKEN_OPTION) == null
               ? null
               : dom.getChild(AUTH_TOKEN_OPTION).getValue());
+
+      pluginConfig.setSkipValidateSdkDependencyVersions(
+          dom.getChild(SKIP_VALIDATE_SDK_DEPENDENCY_VERSIONS_OPTION) != null
+              && Boolean.parseBoolean(
+                  dom.getChild(SKIP_VALIDATE_SDK_DEPENDENCY_VERSIONS_OPTION).getValue()));
     }
 
     return pluginConfig;

--- a/src/main/java/io/sentry/config/PluginConfig.java
+++ b/src/main/java/io/sentry/config/PluginConfig.java
@@ -18,6 +18,9 @@ public class PluginConfig {
   public static final @NotNull String DEFAULT_DEBUG_SENTRY_CLI_STRING = "false";
   public static final boolean DEFAULT_DEBUG = false;
   public static final @NotNull String DEFAULT_DEBUG_STRING = "false";
+  public static final boolean DEFAULT_SKIP_VALIDATE_SDK_DEPENDENCY_VERSIONS = false;
+  public static final @NotNull String DEFAULT_SKIP_VALIDATE_SDK_DEPENDENCY_VERSIONS_STRING =
+      "false";
 
   private boolean skip = DEFAULT_SKIP;
   private boolean skipAutoInstall = DEFAULT_SKIP_AUTO_INSTALL;
@@ -26,6 +29,7 @@ public class PluginConfig {
   private boolean skipSourceBundle = DEFAULT_SKIP_SOURCE_BUNDLE;
   private boolean debugSentryCli = DEFAULT_DEBUG_SENTRY_CLI;
   private boolean debug = DEFAULT_DEBUG;
+  private boolean skipValidateSdkDependencyVersions = DEFAULT_SKIP_VALIDATE_SDK_DEPENDENCY_VERSIONS;
 
   private @Nullable String org;
   private @Nullable String project;
@@ -81,6 +85,11 @@ public class PluginConfig {
     this.skipSourceBundle = skipSourceBundle;
   }
 
+  public void setSkipValidateSdkDependencyVersions(
+      final boolean skipValidateSdkDependencyVersions) {
+    this.skipValidateSdkDependencyVersions = skipValidateSdkDependencyVersions;
+  }
+
   public boolean isSkipAutoInstall() {
     return skipAutoInstall || skip;
   }
@@ -95,6 +104,10 @@ public class PluginConfig {
 
   public boolean isSkipSourceBundle() {
     return skipSourceBundle || skip;
+  }
+
+  public boolean isSkipValidateSdkDependencyVersions() {
+    return skipValidateSdkDependencyVersions;
   }
 
   public @Nullable String getOrg() {

--- a/src/test/java/io/sentry/integration/ValidateSdkDependencyVersionsTestIT.kt
+++ b/src/test/java/io/sentry/integration/ValidateSdkDependencyVersionsTestIT.kt
@@ -58,6 +58,7 @@ class ValidateSdkDependencyVersionsTestIT {
                             <version>1.0-SNAPSHOT</version>
                             <extensions>true</extensions>
                             <configuration>
+                                <skipTelemetry>true</skipTelemetry>
                                 <skipValidateSdkDependencyVersions>$skipValidateSdkDependencyVersions</skipValidateSdkDependencyVersions>
                             </configuration>
                             <executions>

--- a/src/test/java/io/sentry/integration/ValidateSdkDependencyVersionsTestIT.kt
+++ b/src/test/java/io/sentry/integration/ValidateSdkDependencyVersionsTestIT.kt
@@ -1,0 +1,196 @@
+package io.sentry.integration
+
+import org.apache.maven.it.VerificationException
+import org.apache.maven.it.Verifier
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.StandardOpenOption
+import kotlin.io.path.Path
+
+class ValidateSdkDependencyVersionsTestIT {
+    @TempDir
+    lateinit var file: File
+
+    @BeforeEach
+    fun installWrapper() {
+        installMavenWrapper(file, "3.6.3")
+    }
+
+    private fun basePom(
+        dependencies: String = "",
+        skipValidateSdkDependencyVersions: Boolean = false,
+    ): String {
+        return """
+            <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+
+                <groupId>io.sentry.test</groupId>
+                <artifactId>validate-versions</artifactId>
+                <version>1.0-SNAPSHOT</version>
+
+                <packaging>jar</packaging>
+
+                <properties>
+                    <maven.compiler.source>11</maven.compiler.source>
+                    <maven.compiler.target>11</maven.compiler.target>
+                </properties>
+
+                <dependencies>
+                    $dependencies
+                </dependencies>
+
+                <build>
+                    <plugins>
+                        <plugin>
+                            <groupId>io.sentry</groupId>
+                            <artifactId>sentry-maven-plugin</artifactId>
+                            <version>1.0-SNAPSHOT</version>
+                            <extensions>true</extensions>
+                            <configuration>
+                                <skipValidateSdkDependencyVersions>$skipValidateSdkDependencyVersions</skipValidateSdkDependencyVersions>
+                            </configuration>
+                            <executions>
+                                <execution>
+                                    <goals>
+                                        <goal>validateSdkDependencyVersions</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <version>3.11.0</version>
+                            <configuration>
+                                <compilerArgs>
+                                    <arg>-XepDisableAllChecks</arg>
+                                </compilerArgs>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </build>
+            </project>
+            """.trimIndent()
+    }
+
+    fun getPOM(
+        dependencies: String = "",
+        skipValidateSdkDependencyVersions: Boolean = false,
+    ): String {
+        val pomContent =
+            basePom(
+                dependencies = dependencies,
+                skipValidateSdkDependencyVersions = skipValidateSdkDependencyVersions,
+            )
+
+        Files.write(Path("${file.absolutePath}/pom.xml"), pomContent.toByteArray(), StandardOpenOption.CREATE)
+
+        return file.absolutePath
+    }
+
+    @Test
+    @Throws(VerificationException::class, IOException::class)
+    fun `when no Sentry dependencies exist validation succeeds`() {
+        val path = getPOM()
+        val verifier = Verifier(path)
+        verifier.executeGoal("validate")
+        verifier.verifyErrorFreeLog()
+        verifier.resetStreams()
+    }
+
+    @Test
+    @Throws(VerificationException::class, IOException::class)
+    fun `when single Sentry dependency exists validation succeeds`() {
+        val dependencies =
+            """
+            <dependency>
+                <groupId>io.sentry</groupId>
+                <artifactId>sentry-spring-boot</artifactId>
+                <version>8.1.0</version>
+            </dependency>
+            """.trimIndent()
+
+        val path = getPOM(dependencies = dependencies)
+        val verifier = Verifier(path)
+        verifier.executeGoal("validate")
+        verifier.verifyErrorFreeLog()
+        verifier.resetStreams()
+    }
+
+    @Test
+    @Throws(VerificationException::class, IOException::class)
+    fun `when multiple Sentry dependencies with same version exist validation succeeds`() {
+        val dependencies =
+            """
+            <dependency>
+                <groupId>io.sentry</groupId>
+                <artifactId>sentry-spring-boot</artifactId>
+                <version>8.1.0</version>
+            </dependency>
+            <dependency>
+                <groupId>io.sentry</groupId>
+                <artifactId>sentry-logback</artifactId>
+                <version>8.1.0</version>
+            </dependency>
+            """.trimIndent()
+
+        val path = getPOM(dependencies = dependencies)
+        val verifier = Verifier(path)
+        verifier.executeGoal("validate")
+        verifier.verifyErrorFreeLog()
+        verifier.resetStreams()
+    }
+
+    @Test
+    @Throws(VerificationException::class, IOException::class)
+    fun `when multiple Sentry dependencies with different versions exist validation fails`() {
+        val dependencies =
+            """
+            <dependency>
+                <groupId>io.sentry</groupId>
+                <artifactId>sentry</artifactId>
+                <version>8.2.0</version>
+            </dependency>
+            <dependency>
+                <groupId>io.sentry</groupId>
+                <artifactId>sentry-spring-boot</artifactId>
+                <version>8.1.0</version>
+            </dependency>
+            """.trimIndent()
+
+        val path = getPOM(dependencies = dependencies)
+        val verifier = Verifier(path)
+        verifier.executeGoal("validate")
+        verifier.verifyTextInLog("Detected a mismatch in Sentry dependency versions.")
+        verifier.resetStreams()
+    }
+
+    @Test
+    @Throws(VerificationException::class, IOException::class)
+    fun `when Sentry dependency versions validation is skipped validation succeeds despite version mismatch`() {
+        val dependencies =
+            """
+            <dependency>
+                <groupId>io.sentry</groupId>
+                <artifactId>sentry</artifactId>
+                <version>8.2.0</version>
+            </dependency>
+            <dependency>
+                <groupId>io.sentry</groupId>
+                <artifactId>sentry-spring-boot</artifactId>
+                <version>8.1.0</version>
+            </dependency>
+            """.trimIndent()
+
+        val path = getPOM(dependencies = dependencies, skipValidateSdkDependencyVersions = true)
+        val verifier = Verifier(path)
+        verifier.executeGoal("validate")
+        verifier.verifyErrorFreeLog()
+        verifier.resetStreams()
+    }
+}

--- a/src/test/java/io/sentry/integration/autoinstall/PomUtils.kt
+++ b/src/test/java/io/sentry/integration/autoinstall/PomUtils.kt
@@ -1,4 +1,4 @@
-import io.sentry.autoinstall.Constants
+import io.sentry.Constants
 
 fun basePom(
     dependencies: String?,
@@ -21,7 +21,7 @@ fun basePom(
             """
             <dependency>
                 <groupId>${Constants.SENTRY_GROUP_ID}</groupId>
-                <artifactId>${Constants.SENTRY_ARTIFACT_ID}</artifactId>
+                <artifactId>${Constants.SENTRY_SDK_ARTIFACT_ID}</artifactId>
                 <version>$it</version>
             </dependency>
             """.trimIndent()


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Adds a new task `validateSdkDependencyVersions` that checks for dependencies in the `io.sentry` group (except for the plugin itself and the core SDK `io.sentry:sentry`, as an explicit dependency on the core SDK module could be valid if the intention is to override the default version used by the plugin) and validates if they have consistent versions.

Currently, customers would need to add 
```xml
<goal>validateSdkDependencyVersions</goal>
```
to their `pom.xml` to enable running this new task.
I need to investigate on how to make it run automatically by default.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/getsentry/sentry-maven-plugin/issues/123

## :green_heart: How did you test it?
I have tested different scenarios manually with the example project included in this repo.
I have also added integration tests, but it seems that they are not running this new task, even when explicitly specifying it as an execution goal.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [X] No breaking changes

## :crystal_ball: Next steps

- [x] Fix integration tests
- [X] Have the task run automatically in the `validate` phase (not possible)
- [X] update changelog
- [ ] https://github.com/getsentry/sentry-docs/pull/12911