### PR TITLE
Mark the Mojos as thread-safe

### DIFF
--- a/src/main/java/io/sentry/ReportDependenciesMojo.java
+++ b/src/main/java/io/sentry/ReportDependenciesMojo.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Mojo(name = "reportDependencies", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
+@Mojo(name = "reportDependencies", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
 public class ReportDependenciesMojo extends AbstractMojo {
 
   public static final @NotNull String EXTERNAL_MODULES_FILE = "external-modules.txt";

--- a/src/main/java/io/sentry/UploadSourceBundleMojo.java
+++ b/src/main/java/io/sentry/UploadSourceBundleMojo.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Mojo(name = "uploadSourceBundle", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
+@Mojo(name = "uploadSourceBundle", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true)
 public class UploadSourceBundleMojo extends AbstractMojo {
 
   private static Logger logger = LoggerFactory.getLogger(UploadSourceBundleMojo.class);


### PR DESCRIPTION
## :scroll: Description

Just marks the Mojos as thread-safe, this reduces the WARNING-level logging by Maven when running multi-threaded builds:
```
| [INFO] --------------------------------[ jar ]---------------------------------
| [WARNING] *****************************************************************
| [WARNING] * Your build is requesting parallel execution, but this         *
| [WARNING] * project contains the following plugin(s) that have goals not  *
| [WARNING] * marked as thread-safe to support parallel execution.          *
| [WARNING] * While this /may/ work fine, please look for plugin updates    *
| [WARNING] * and/or request plugins be made thread-safe.                   *
| [WARNING] * If reporting an issue, report it against the plugin in        *
| [WARNING] * question, not against Apache Maven.                           *
| [WARNING] *****************************************************************
| [WARNING] The following plugins are not marked as thread-safe in %module-name%:
| [WARNING]   io.sentry:sentry-maven-plugin:0.2.0
| [WARNING]
| [WARNING] Enable debug to see precisely which goals are not marked as thread-safe.
| [WARNING] *****************************************************************
```


## :bulb: Motivation and Context

My understanding is that Sentry's plugin is in fact thread-safe, but was just never marked as such. Avoiding the warnings would help us, as we are paying attention to other warnings that are mainly coming from the Checkstyle plugin and having these mixed makes it harder to notice to those.


## :green_heart: How did you test it?

Did not test the change

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] No breaking changes


## :crystal_ball: Next steps
