### PR TITLE
Support multiple source roots

### DIFF
--- a/examples/sentry-maven-plugin-example/pom.xml
+++ b/examples/sentry-maven-plugin-example/pom.xml
@@ -48,6 +48,9 @@
                     <skipAutoInstall>false</skipAutoInstall>
                     <skipTelemetry>false</skipTelemetry>
                     <skipValidateSdkDependencyVersions>false</skipValidateSdkDependencyVersions>
+                    <additionalSourceDirsForSourceContext>
+                        <value>src/main/extra_param</value>
+                    </additionalSourceDirsForSourceContext>
                 </configuration>
                 <executions>
                     <execution>
@@ -81,6 +84,24 @@
                         <goals>
                             <goal>single</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/main/extra</source>
+                            </sources>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/examples/sentry-maven-plugin-example/src/main/extra/io/sentry/samples/maven/extra/MyClass.java
+++ b/examples/sentry-maven-plugin-example/src/main/extra/io/sentry/samples/maven/extra/MyClass.java
@@ -1,0 +1,8 @@
+package io.sentry.samples.maven.extra;
+import io.sentry.Sentry;
+
+public class MyClass {
+    public static void myFunction() {
+        Sentry.captureException(new RuntimeException("Exception thrown in additional sources root"));
+    }
+}

--- a/examples/sentry-maven-plugin-example/src/main/extra_param/MyClass.java
+++ b/examples/sentry-maven-plugin-example/src/main/extra_param/MyClass.java
@@ -1,0 +1,3 @@
+// Sample class that will be added to the source bundle using the `additionalSourceDirsForSourceContext` plugin parameter
+// even though the directory is not marked as a compile source root
+public class MyClass {}

--- a/examples/sentry-maven-plugin-example/src/main/java/io/sentry/samples/maven/SampleApplication.java
+++ b/examples/sentry-maven-plugin-example/src/main/java/io/sentry/samples/maven/SampleApplication.java
@@ -179,6 +179,9 @@ public class SampleApplication {
         // marks transaction as finished and sends it together with all child spans to Sentry
         transaction.finish();
 
+        // Throw an exception from a function defined in an additional compile source root
+        io.sentry.samples.maven.extra.MyClass.myFunction();
+
         // All events that have not been sent yet are being flushed on JVM exit. Events can be also
         // flushed manually:
         // Sentry.close();

--- a/src/main/java/io/sentry/UploadSourceBundleMojo.java
+++ b/src/main/java/io/sentry/UploadSourceBundleMojo.java
@@ -1,13 +1,14 @@
 package io.sentry;
 
 import static io.sentry.config.PluginConfig.*;
-import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
 
 import io.sentry.cli.SentryCliRunner;
 import io.sentry.telemetry.SentryTelemetryService;
 import java.io.*;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.*;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Resource;
@@ -59,6 +60,9 @@ public class UploadSourceBundleMojo extends AbstractMojo {
   @Parameter(defaultValue = "${session}", readonly = true)
   private @NotNull MavenSession mavenSession;
 
+  @Parameter(property = "additionalSourceDirsForSourceContext")
+  private final @NotNull List<String> additionalSourceDirsForSourceContext = new ArrayList<>();
+
   @Parameter(defaultValue = DEFAULT_SKIP_STRING)
   private boolean skip;
 
@@ -78,13 +82,74 @@ public class UploadSourceBundleMojo extends AbstractMojo {
     }
 
     final @NotNull String bundleId = UUID.randomUUID().toString();
+    final @NotNull File collectedSourcesTargetDir = new File(sentryBuildDir(), "collected-sources");
     final @NotNull File sourceBundleTargetDir = new File(sentryBuildDir(), "source-bundle");
     final @NotNull SentryCliRunner cliRunner =
         new SentryCliRunner(
             debugSentryCli, sentryCliExecutablePath, mavenProject, mavenSession, pluginManager);
+
     createDebugMetaPropertiesFile(bundleId);
-    bundleSources(cliRunner, bundleId, sourceBundleTargetDir);
+    collectSources(bundleId, collectedSourcesTargetDir);
+    bundleSources(cliRunner, bundleId, collectedSourcesTargetDir, sourceBundleTargetDir);
     uploadSourceBundle(cliRunner, sourceBundleTargetDir);
+  }
+
+  private void collectSources(@NotNull String bundleId, @NotNull File outputDir) {
+    final @Nullable ISpan span = SentryTelemetryService.getInstance().startTask("collectSources");
+    logger.debug("Collecting files from source directories");
+
+    if (!outputDir.exists()) {
+      outputDir.mkdirs();
+    }
+
+    final @Nullable List<String> sourceRootsPaths = mavenProject.getCompileSourceRoots();
+    final @NotNull List<String> sourceDirsPaths =
+        sourceRootsPaths == null ? new ArrayList<>() : new ArrayList<>(sourceRootsPaths);
+    sourceDirsPaths.removeIf(Objects::isNull);
+    sourceDirsPaths.addAll(additionalSourceDirsForSourceContext);
+
+    logger.debug(
+        "Copying files from the following directories to {} for inclusion in source bundle: {}",
+        outputDir,
+        String.join(",", sourceDirsPaths));
+    for (final @NotNull String sourceDirPath : sourceDirsPaths) {
+      try {
+        final @NotNull File sourceDir = new File(sourceDirPath);
+        final @NotNull Path sourceDirAbsolutePath = sourceDir.toPath().toAbsolutePath().normalize();
+
+        if (!sourceDir.exists()) {
+          logger.error(
+              "Not collecting sources in {}: directory does not exist", sourceDirAbsolutePath);
+          continue;
+        }
+        if (!sourceDir.isDirectory()) {
+          logger.error("Not collecting sources in {}: not a directory", sourceDirAbsolutePath);
+          continue;
+        }
+        logger.debug("Collecting sources in {}", sourceDirPath);
+
+        Files.walk(sourceDirAbsolutePath)
+            .forEach(
+                (sourcePath) -> {
+                  final @NotNull Path relativePath = sourceDirAbsolutePath.relativize(sourcePath);
+                  final @NotNull Path destinationPath = outputDir.toPath().resolve(relativePath);
+
+                  if (sourcePath.toFile().isFile()) {
+                    try {
+                      Files.createDirectories(destinationPath.getParent());
+                      Files.copy(sourcePath, destinationPath, StandardCopyOption.REPLACE_EXISTING);
+                    } catch (IOException e) {
+                      logger.error(
+                          "Failed to copy file from {} to {}", sourcePath, destinationPath, e);
+                    }
+                  }
+                });
+      } catch (Throwable t) {
+        logger.error("Failed to collect sources in {}", sourceDirPath, t);
+        SentryTelemetryService.getInstance().captureError(t, "bundleSources " + sourceDirPath);
+      }
+    }
+    SentryTelemetryService.getInstance().endTask(span);
   }
 
   private @NotNull File sentryBuildDir() {
@@ -94,6 +159,7 @@ public class UploadSourceBundleMojo extends AbstractMojo {
   private void bundleSources(
       final @NotNull SentryCliRunner cliRunner,
       final @NotNull String bundleId,
+      final @NotNull File collectedSourcesDir,
       final @NotNull File sourceBundleTargetDir)
       throws MojoExecutionException {
     final @Nullable ISpan span = SentryTelemetryService.getInstance().startTask("bundleSources");
@@ -101,56 +167,41 @@ public class UploadSourceBundleMojo extends AbstractMojo {
       if (!sourceBundleTargetDir.exists()) {
         sourceBundleTargetDir.mkdirs();
       }
+      logger.debug(
+          "Bundling collected sources located in {}", collectedSourcesDir.getAbsolutePath());
 
       final @NotNull List<String> bundleSourcesCommand = new ArrayList<>();
-      final @NotNull List<String> sourceRoots = mavenProject.getCompileSourceRoots();
-      final @Nullable String sourceRoot =
-          sourceRoots != null && !sourceRoots.isEmpty() ? sourceRoots.get(0) : null;
 
-      if (sourceRoot != null && new File(sourceRoot).exists()) {
-        if (sourceRoots.size() > 1) {
-          logger.warn("There's more than one source root, using {}", sourceRoot);
-        }
-
-        if (debugSentryCli) {
-          bundleSourcesCommand.add("--log-level=debug");
-        }
-
-        final @NotNull List<String> tracingArgs = SentryTelemetryService.getInstance().traceCli();
-        for (final @NotNull String tracingArg : tracingArgs) {
-          bundleSourcesCommand.add(tracingArg);
-        }
-
-        /*
-         * TODO maybe at some point copy all of them into one dir and pass that to
-         *  sentry-cli or allow sentry-cli to take more than one dir
-         */
-        logger.debug("Bundling sources located in {}", sourceRoot);
-
-        if (url != null) {
-          bundleSourcesCommand.add("--url=" + url);
-        }
-        if (authToken != null) {
-          bundleSourcesCommand.add("--auth-token=" + authToken);
-        }
-
-        bundleSourcesCommand.add("debug-files");
-        bundleSourcesCommand.add("bundle-jvm");
-        bundleSourcesCommand.add(
-            "--output=" + cliRunner.escape(sourceBundleTargetDir.getAbsolutePath()));
-        bundleSourcesCommand.add("--debug-id=" + bundleId);
-        if (org != null) {
-          bundleSourcesCommand.add("--org=" + org);
-        }
-        if (project != null) {
-          bundleSourcesCommand.add("--project=" + project);
-        }
-        bundleSourcesCommand.add(cliRunner.escape(sourceRoot));
-
-        cliRunner.runSentryCli(String.join(" ", bundleSourcesCommand), true);
-      } else {
-        logger.info("Skipping module, as it doesn't have any source roots");
+      if (debugSentryCli) {
+        bundleSourcesCommand.add("--log-level=debug");
       }
+
+      final @NotNull List<String> tracingArgs = SentryTelemetryService.getInstance().traceCli();
+      for (final @NotNull String tracingArg : tracingArgs) {
+        bundleSourcesCommand.add(tracingArg);
+      }
+
+      if (url != null) {
+        bundleSourcesCommand.add("--url=" + url);
+      }
+      if (authToken != null) {
+        bundleSourcesCommand.add("--auth-token=" + authToken);
+      }
+
+      bundleSourcesCommand.add("debug-files");
+      bundleSourcesCommand.add("bundle-jvm");
+      bundleSourcesCommand.add(
+          "--output=" + cliRunner.escape(sourceBundleTargetDir.getAbsolutePath()));
+      bundleSourcesCommand.add("--debug-id=" + bundleId);
+      if (org != null) {
+        bundleSourcesCommand.add("--org=" + org);
+      }
+      if (project != null) {
+        bundleSourcesCommand.add("--project=" + project);
+      }
+      bundleSourcesCommand.add(cliRunner.escape(collectedSourcesDir.getAbsolutePath()));
+
+      cliRunner.runSentryCli(String.join(" ", bundleSourcesCommand), true);
     } catch (Throwable t) {
       SentryTelemetryService.getInstance().captureError(t, "bundleSources");
       throw t;

--- a/src/main/java/io/sentry/config/ConfigParser.java
+++ b/src/main/java/io/sentry/config/ConfigParser.java
@@ -3,6 +3,8 @@ package io.sentry.config;
 import static io.sentry.Constants.SENTRY_GROUP_ID;
 import static io.sentry.Constants.SENTRY_PLUGIN_ARTIFACT_ID;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
@@ -24,6 +26,8 @@ public class ConfigParser {
   private static final @NotNull String PROJECT_OPTION = "project";
   private static final @NotNull String URL_OPTION = "url";
   private static final @NotNull String AUTH_TOKEN_OPTION = "authToken";
+  private static final @NotNull String ADDITIONAL_SOURCE_DIRS_FOR_SOURCE_CONTEXT =
+      "additionalSourceDirsForSourceContext";
 
   public @NotNull PluginConfig parseConfig(final @NotNull MavenProject project) {
     final @NotNull PluginConfig pluginConfig = new PluginConfig();
@@ -90,6 +94,13 @@ public class ConfigParser {
           dom.getChild(SKIP_VALIDATE_SDK_DEPENDENCY_VERSIONS_OPTION) != null
               && Boolean.parseBoolean(
                   dom.getChild(SKIP_VALIDATE_SDK_DEPENDENCY_VERSIONS_OPTION).getValue()));
+
+      pluginConfig.setAdditionalSourceDirsForSourceContext(
+          dom.getChild(ADDITIONAL_SOURCE_DIRS_FOR_SOURCE_CONTEXT) == null
+              ? ""
+              : Arrays.stream(dom.getChild(ADDITIONAL_SOURCE_DIRS_FOR_SOURCE_CONTEXT).getChildren())
+                  .map(Xpp3Dom::getValue)
+                  .collect(Collectors.joining(",")));
     }
 
     return pluginConfig;

--- a/src/main/java/io/sentry/config/PluginConfig.java
+++ b/src/main/java/io/sentry/config/PluginConfig.java
@@ -21,6 +21,7 @@ public class PluginConfig {
   public static final boolean DEFAULT_SKIP_VALIDATE_SDK_DEPENDENCY_VERSIONS = false;
   public static final @NotNull String DEFAULT_SKIP_VALIDATE_SDK_DEPENDENCY_VERSIONS_STRING =
       "false";
+  public static final @NotNull String DEFAULT_ADDITIONAL_SOURCE_DIRS_FOR_SOURCE_CONTEXT = "";
 
   private boolean skip = DEFAULT_SKIP;
   private boolean skipAutoInstall = DEFAULT_SKIP_AUTO_INSTALL;
@@ -30,6 +31,8 @@ public class PluginConfig {
   private boolean debugSentryCli = DEFAULT_DEBUG_SENTRY_CLI;
   private boolean debug = DEFAULT_DEBUG;
   private boolean skipValidateSdkDependencyVersions = DEFAULT_SKIP_VALIDATE_SDK_DEPENDENCY_VERSIONS;
+  private @NotNull String additionalSourceDirsForSourceContext =
+      DEFAULT_ADDITIONAL_SOURCE_DIRS_FOR_SOURCE_CONTEXT;
 
   private @Nullable String org;
   private @Nullable String project;
@@ -140,5 +143,14 @@ public class PluginConfig {
 
   public void setAuthToken(final @Nullable String authToken) {
     this.authToken = authToken;
+  }
+
+  public @NotNull String getAdditionalSourceDirsForSourceContext() {
+    return additionalSourceDirsForSourceContext;
+  }
+
+  public void setAdditionalSourceDirsForSourceContext(
+      final @NotNull String additionalSourceDirsForSourceContext) {
+    this.additionalSourceDirsForSourceContext = additionalSourceDirsForSourceContext;
   }
 }

--- a/src/main/java/io/sentry/telemetry/SentryTelemetryService.java
+++ b/src/main/java/io/sentry/telemetry/SentryTelemetryService.java
@@ -108,6 +108,9 @@ public class SentryTelemetryService {
               options.setTag(
                   "SENTRY_includeSourceContext",
                   String.valueOf(!pluginConfig.isSkipSourceBundle()));
+              options.setTag(
+                  "SENTRY_additionalSourceDirsForSourceContext",
+                  pluginConfig.getAdditionalSourceDirsForSourceContext());
             });
         scopes = Sentry.forkedScopes("SentryTelemetryService");
         token = scopes.makeCurrent();


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Adds support for multiple source roots.

Works similarly to our `sentry-android-gradle-plugin`:
- The contents of the source roots (+ any additional dirs passed with the `additionalSourceDirsForSourceContext` plugin parameter get copied to `target/sentry/collected-sources`
- Then they are bundled and sent by `sentry-cli` as normal

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #70 

## :green_heart: How did you test it?
Tested manually with the sample project

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [X] I updated the docs if needed
- [X] No breaking changes

## :crystal_ball: Next steps
Document it