### PR TITLE
Use project's Maven wrapper to install Maven wrapper for integration tests

### DIFF
--- a/src/test/java/io/sentry/integration/CommonPomUtils.kt
+++ b/src/test/java/io/sentry/integration/CommonPomUtils.kt
@@ -5,7 +5,6 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import java.nio.file.StandardOpenOption
-import kotlin.io.path.Path
 
 /**
  * Utility to install a specific version of the Maven wrapper for tests
@@ -35,7 +34,7 @@ fun installMavenWrapper(
         addCliOption("-Dmaven=$mavenVersionToUse")
         executeGoal("wrapper:wrapper")
     }
-    Files.delete(Path("${directory.absolutePath}/pom.xml"))
+    Files.delete(directory.toPath().resolve("pom.xml"))
 }
 
 /**

--- a/src/test/java/io/sentry/integration/CommonPomUtils.kt
+++ b/src/test/java/io/sentry/integration/CommonPomUtils.kt
@@ -3,13 +3,19 @@ package io.sentry.integration
 import org.apache.maven.it.Verifier
 import java.io.File
 import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import java.nio.file.StandardOpenOption
 import kotlin.io.path.Path
 
+/**
+ * Utility to install a specific version of the Maven wrapper for tests
+ */
 fun installMavenWrapper(
-    file: File,
+    directory: File,
     version: String,
 ) {
+    bootstrapMavenWrapper(directory)
+
     val mavenVersionToUse = System.getProperty("maven.test.version") ?: version
 
     val emptyPom =
@@ -23,11 +29,49 @@ fun installMavenWrapper(
         </project>
         """.trimIndent()
 
-    Files.write(Path("${file.absolutePath}/pom.xml"), emptyPom.toByteArray(), StandardOpenOption.CREATE)
-    Verifier(file.absolutePath).apply {
+    Files.write(directory.toPath().resolve("pom.xml"), emptyPom.toByteArray(), StandardOpenOption.CREATE)
+    Verifier(directory.absolutePath).apply {
         addCliOption("-N")
         addCliOption("-Dmaven=$mavenVersionToUse")
         executeGoal("wrapper:wrapper")
     }
-    Files.delete(Path("${file.absolutePath}/pom.xml"))
+    Files.delete(Path("${directory.absolutePath}/pom.xml"))
+}
+
+/**
+ * If no Maven wrapper is present in `targetDirectory`, obtain it by copying it from this project's root directory
+ */
+private fun bootstrapMavenWrapper(targetDirectory: File) {
+    val projectRoot = File(System.getProperty("user.dir"))
+
+    if (File(targetDirectory.toPath().resolve("mvnw").toString()).exists()) {
+        return
+    }
+
+    Files.copy(
+        projectRoot.toPath().resolve("mvnw"),
+        targetDirectory.toPath().resolve("mvnw"),
+        StandardCopyOption.REPLACE_EXISTING,
+    )
+    Files.copy(
+        projectRoot.toPath().resolve("mvnw.cmd"),
+        targetDirectory.toPath().resolve("mvnw.cmd"),
+        StandardCopyOption.REPLACE_EXISTING,
+    )
+
+    val sourceMvnDir = File(projectRoot, ".mvn")
+    val targetMvnDir = File(targetDirectory, ".mvn")
+    targetMvnDir.mkdirs()
+    sourceMvnDir.walk().forEach { sourceFile ->
+        if (sourceFile.isFile) {
+            val relativePath = sourceFile.relativeTo(sourceMvnDir)
+            val targetFile = File(targetMvnDir, relativePath.path)
+            targetFile.parentFile.mkdirs()
+            Files.copy(
+                sourceFile.toPath(),
+                targetFile.toPath(),
+                StandardCopyOption.REPLACE_EXISTING,
+            )
+        }
+    }
 }


### PR DESCRIPTION
#skip-changelog

## :scroll: Description
<!--- Describe your changes in detail -->
This way we won't need a separate installation of Maven to run the integration tests.