### PR TITLE
Add MojoExecutionException as cause of SentryCliException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add MojoExecutionException as cause of SentryCliException ([#170](https://github.com/getsentry/sentry-maven-plugin/pull/170))
+
 ## 0.7.0
 
 ### Dependencies

--- a/src/main/java/io/sentry/cli/SentryCliException.java
+++ b/src/main/java/io/sentry/cli/SentryCliException.java
@@ -4,11 +4,6 @@ public class SentryCliException extends RuntimeException {
 
   private CliFailureReason reason;
 
-  public SentryCliException(CliFailureReason reason) {
-    super(reason.getText());
-    this.reason = reason;
-  }
-
   public SentryCliException(CliFailureReason reason, Throwable cause) {
     super(reason.getText(), cause);
     this.reason = reason;

--- a/src/main/java/io/sentry/cli/SentryCliException.java
+++ b/src/main/java/io/sentry/cli/SentryCliException.java
@@ -9,6 +9,11 @@ public class SentryCliException extends RuntimeException {
     this.reason = reason;
   }
 
+  public SentryCliException(CliFailureReason reason, Throwable cause) {
+    super(reason.getText(), cause);
+    this.reason = reason;
+  }
+
   public CliFailureReason getReason() {
     return reason;
   }

--- a/src/main/java/io/sentry/cli/SentryCliRunner.java
+++ b/src/main/java/io/sentry/cli/SentryCliRunner.java
@@ -83,7 +83,7 @@ public class SentryCliRunner {
         final @Nullable String output = collectAndMaybePrintOutput(logFile, true);
         if (output != null) {
           final @NotNull CliFailureReason failureReason = failureReasonFromCliOutput(output);
-          throw new SentryCliException(failureReason);
+          throw new SentryCliException(failureReason, e);
         }
       }
       throw e;


### PR DESCRIPTION
## :scroll: Description

When CLI fails to run, the reason might not be strictly due to CLI itself but due to other failures, such as not having permission to write the file where we attempt to save the output of CLI, as seen in #169 .

To uncover those failures, we now attach the `MojoExecutionException` as cause of the `SentryCliException`.

Note that
- this is a breaking change (but we could also just make a new constructor)
- it will create new groups in our build tool crash reporting project in Sentry

Tested manually by verifying that the cause and its stack trace are logged upon failure.