### PR TITLE
Update Sentry SDK version to 8.4.0

### DIFF
--- a/src/main/resources/sentry-sdk.properties
+++ b/src/main/resources/sentry-sdk.properties
@@ -1,1 +1,1 @@
-sdk_version = 8.34.1
+sdk_version = 8.4.0


### PR DESCRIPTION
Bot-generated dependency update PRs are not being merged, causing the plugin to resolve an outdated version instead of the intended one.
