### PR TITLE
fix(auto-install): Use Sentry BOM version for installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Use imported Sentry BOM versions for auto-installed dependencies ([#265](https://github.com/getsentry/sentry-maven-plugin/pull/265))
+
 ## 0.11.0
 
 ### Features

--- a/src/main/java/io/sentry/Constants.java
+++ b/src/main/java/io/sentry/Constants.java
@@ -5,5 +5,8 @@ import org.jetbrains.annotations.NotNull;
 public class Constants {
   public static final @NotNull String SENTRY_GROUP_ID = "io.sentry";
   public static final @NotNull String SENTRY_SDK_ARTIFACT_ID = "sentry";
+  public static final @NotNull String SENTRY_BOM_ARTIFACT_ID = "sentry-bom";
+  public static final @NotNull String SENTRY_OPENTELEMETRY_BOM_ARTIFACT_ID =
+      "sentry-opentelemetry-bom";
   public static final @NotNull String SENTRY_PLUGIN_ARTIFACT_ID = "sentry-maven-plugin";
 }

--- a/src/main/java/io/sentry/SentryInstallerLifecycleParticipant.java
+++ b/src/main/java/io/sentry/SentryInstallerLifecycleParticipant.java
@@ -24,6 +24,7 @@ import io.sentry.autoinstall.log4j2.Log4j2InstallStrategy;
 import io.sentry.autoinstall.logback.LogbackInstallStrategy;
 import io.sentry.autoinstall.quartz.QuartzInstallStrategy;
 import io.sentry.autoinstall.spring.*;
+import io.sentry.autoinstall.util.ManagedSentryVersionResolver;
 import io.sentry.config.ConfigParser;
 import io.sentry.config.PluginConfig;
 import io.sentry.telemetry.SentryTelemetryService;
@@ -105,8 +106,10 @@ public class SentryInstallerLifecycleParticipant extends AbstractMavenLifecycleP
         final @NotNull Model currModel = project.getModel();
 
         final @NotNull List<Dependency> dependencyList = currModel.getDependencies();
+        final @Nullable String managedSentryVersion =
+            ManagedSentryVersionResolver.getManagedSentryVersion(project);
         final @Nullable String sentryVersion =
-            new SentryInstaller().install(dependencyList, resolvedArtifacts);
+            new SentryInstaller().install(dependencyList, resolvedArtifacts, managedSentryVersion);
 
         if (sentryVersion == null) {
           logger.error(

--- a/src/main/java/io/sentry/autoinstall/SentryInstaller.java
+++ b/src/main/java/io/sentry/autoinstall/SentryInstaller.java
@@ -25,12 +25,6 @@ public class SentryInstaller {
 
   public @Nullable String install(
       final @NotNull List<Dependency> dependencyList,
-      final @NotNull List<Artifact> resolvedArtifacts) {
-    return install(dependencyList, resolvedArtifacts, null);
-  }
-
-  public @Nullable String install(
-      final @NotNull List<Dependency> dependencyList,
       final @NotNull List<Artifact> resolvedArtifacts,
       final @Nullable String managedSentryVersion) {
 

--- a/src/main/java/io/sentry/autoinstall/SentryInstaller.java
+++ b/src/main/java/io/sentry/autoinstall/SentryInstaller.java
@@ -26,6 +26,13 @@ public class SentryInstaller {
   public @Nullable String install(
       final @NotNull List<Dependency> dependencyList,
       final @NotNull List<Artifact> resolvedArtifacts) {
+    return install(dependencyList, resolvedArtifacts, null);
+  }
+
+  public @Nullable String install(
+      final @NotNull List<Dependency> dependencyList,
+      final @NotNull List<Artifact> resolvedArtifacts,
+      final @Nullable String managedSentryVersion) {
 
     final @Nullable Artifact sentryDependency =
         resolvedArtifacts.stream()
@@ -40,7 +47,8 @@ public class SentryInstaller {
       logger.info("Sentry already installed " + sentryDependency.getVersion());
       return sentryDependency.getVersion();
     } else {
-      final @Nullable String sentryVersion = SdkVersionInfo.getSentryVersion();
+      final @Nullable String sentryVersion =
+          managedSentryVersion != null ? managedSentryVersion : SdkVersionInfo.getSentryVersion();
 
       if (sentryVersion == null) {
         logger.error("Unable to load sentry version, Sentry SDK cannot be auto-installed");

--- a/src/main/java/io/sentry/autoinstall/util/ManagedSentryVersionResolver.java
+++ b/src/main/java/io/sentry/autoinstall/util/ManagedSentryVersionResolver.java
@@ -1,0 +1,88 @@
+package io.sentry.autoinstall.util;
+
+import static io.sentry.Constants.SENTRY_BOM_ARTIFACT_ID;
+import static io.sentry.Constants.SENTRY_GROUP_ID;
+import static io.sentry.Constants.SENTRY_OPENTELEMETRY_BOM_ARTIFACT_ID;
+import static io.sentry.Constants.SENTRY_SDK_ARTIFACT_ID;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Model;
+import org.apache.maven.project.MavenProject;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class ManagedSentryVersionResolver {
+  private static final @NotNull String SENTRY_OPENTELEMETRY_ARTIFACT_PREFIX =
+      "sentry-opentelemetry-";
+
+  private ManagedSentryVersionResolver() {}
+
+  public static @Nullable String getManagedSentryVersion(final @NotNull MavenProject project) {
+    final @NotNull Set<String> managedVersions = new LinkedHashSet<>();
+
+    collectManagedSentryVersions(project.getDependencyManagement(), project, managedVersions);
+    collectManagedSentryVersions(
+        project.getModel().getDependencyManagement(), project, managedVersions);
+
+    final @Nullable Model originalModel = project.getOriginalModel();
+    if (originalModel != null) {
+      collectManagedSentryVersions(
+          originalModel.getDependencyManagement(), project, managedVersions);
+    }
+
+    return managedVersions.stream().findFirst().orElse(null);
+  }
+
+  private static void collectManagedSentryVersions(
+      final @Nullable DependencyManagement dependencyManagement,
+      final @NotNull MavenProject project,
+      final @NotNull Set<String> managedVersions) {
+    if (dependencyManagement == null) {
+      return;
+    }
+
+    for (final @NotNull Dependency dependency : dependencyManagement.getDependencies()) {
+      if (!isSentryManagedVersionSource(dependency)) {
+        continue;
+      }
+
+      final @Nullable String version = resolveVersion(dependency.getVersion(), project);
+      if (version != null) {
+        managedVersions.add(version);
+      }
+    }
+  }
+
+  private static boolean isSentryManagedVersionSource(final @NotNull Dependency dependency) {
+    if (!SENTRY_GROUP_ID.equals(dependency.getGroupId())) {
+      return false;
+    }
+
+    final @NotNull String artifactId = dependency.getArtifactId();
+    return SENTRY_SDK_ARTIFACT_ID.equals(artifactId)
+        || SENTRY_BOM_ARTIFACT_ID.equals(artifactId)
+        || SENTRY_OPENTELEMETRY_BOM_ARTIFACT_ID.equals(artifactId)
+        || artifactId.startsWith(SENTRY_OPENTELEMETRY_ARTIFACT_PREFIX);
+  }
+
+  private static @Nullable String resolveVersion(
+      final @Nullable String version, final @NotNull MavenProject project) {
+    if (version == null || version.trim().isEmpty()) {
+      return null;
+    }
+
+    if (version.startsWith("${") && version.endsWith("}")) {
+      final @NotNull String propertyName = version.substring(2, version.length() - 1);
+      return resolveVersion(project.getProperties().getProperty(propertyName), project);
+    }
+
+    if (version.contains("${")) {
+      return null;
+    }
+
+    return version;
+  }
+}

--- a/src/test/java/io/sentry/integration/autoinstall/PomUtils.kt
+++ b/src/test/java/io/sentry/integration/autoinstall/PomUtils.kt
@@ -4,6 +4,7 @@ fun basePom(
     dependencies: String?,
     installedSentryVersion: String? = null,
     pluginConfiguration: String = "",
+    dependencyManagement: String = "",
 ): String {
     val sentryPlugin =
         """
@@ -37,6 +38,8 @@ fun basePom(
             <version>1.0-SNAPSHOT</version>
 
             <packaging>jar</packaging>
+
+            $dependencyManagement
 
             <properties>
                 <maven.compiler.source>11</maven.compiler.source>

--- a/src/test/java/io/sentry/integration/autoinstall/SentryAutoInstallTestIT.kt
+++ b/src/test/java/io/sentry/integration/autoinstall/SentryAutoInstallTestIT.kt
@@ -26,8 +26,9 @@ class SentryAutoInstallTestIT {
     fun getPOM(
         installedSentryVersion: String? = null,
         pluginConfiguration: String = "",
+        dependencyManagement: String = "",
     ): String {
-        val pomContent = basePom("", installedSentryVersion, pluginConfiguration)
+        val pomContent = basePom("", installedSentryVersion, pluginConfiguration, dependencyManagement)
 
         Files.write(Path("${file.absolutePath}/pom.xml"), pomContent.toByteArray(), StandardOpenOption.CREATE)
 
@@ -42,6 +43,33 @@ class SentryAutoInstallTestIT {
         verifier.isAutoclean = false
         verifier.executeGoal("install")
         verifier.verifyFilePresent("target/lib/sentry-${SdkVersionInfo.getSentryVersion()}.jar")
+        verifier.resetStreams()
+    }
+
+    @Test
+    @Throws(VerificationException::class, IOException::class)
+    fun `installs sentry with version from sentry bom`() {
+        val bomVersion = "8.33.0"
+        val dependencyManagement =
+            """
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.sentry</groupId>
+                        <artifactId>sentry-bom</artifactId>
+                        <version>$bomVersion</version>
+                        <type>pom</type>
+                        <scope>import</scope>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+            """.trimIndent()
+        val path = getPOM(dependencyManagement = dependencyManagement)
+        val verifier = Verifier(path)
+        verifier.isAutoclean = false
+        verifier.executeGoal("install")
+        verifier.verifyFilePresent("target/lib/sentry-$bomVersion.jar")
+        verifier.verifyTextInLog("Installing Sentry with version $bomVersion")
         verifier.resetStreams()
     }
 

--- a/src/test/java/io/sentry/unit/autoinstall/ManagedSentryVersionResolverTest.kt
+++ b/src/test/java/io/sentry/unit/autoinstall/ManagedSentryVersionResolverTest.kt
@@ -1,0 +1,59 @@
+package io.sentry.unit.autoinstall
+
+import io.sentry.Constants.SENTRY_BOM_ARTIFACT_ID
+import io.sentry.Constants.SENTRY_GROUP_ID
+import io.sentry.Constants.SENTRY_OPENTELEMETRY_BOM_ARTIFACT_ID
+import io.sentry.autoinstall.util.ManagedSentryVersionResolver
+import org.apache.maven.model.Dependency
+import org.apache.maven.model.DependencyManagement
+import org.apache.maven.model.Model
+import org.apache.maven.project.MavenProject
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class ManagedSentryVersionResolverTest {
+    @Test
+    fun `detects sentry bom version`() {
+        val project = projectWithDependencyManagement(bom(SENTRY_BOM_ARTIFACT_ID, "8.33.0"))
+
+        assertEquals("8.33.0", ManagedSentryVersionResolver.getManagedSentryVersion(project))
+    }
+
+    @Test
+    fun `detects sentry opentelemetry bom version`() {
+        val project = projectWithDependencyManagement(bom(SENTRY_OPENTELEMETRY_BOM_ARTIFACT_ID, "8.32.0"))
+
+        assertEquals("8.32.0", ManagedSentryVersionResolver.getManagedSentryVersion(project))
+    }
+
+    @Test
+    fun `resolves bom version property`() {
+        val project = projectWithDependencyManagement(bom(SENTRY_BOM_ARTIFACT_ID, "\${sentry.version}"))
+        project.properties.setProperty("sentry.version", "8.31.0")
+
+        assertEquals("8.31.0", ManagedSentryVersionResolver.getManagedSentryVersion(project))
+    }
+
+    private fun projectWithDependencyManagement(vararg dependencies: Dependency): MavenProject {
+        val dependencyManagement = DependencyManagement()
+        dependencies.forEach(dependencyManagement::addDependency)
+
+        val model = Model()
+        model.dependencyManagement = dependencyManagement
+
+        return MavenProject(model)
+    }
+
+    private fun bom(
+        artifactId: String,
+        version: String,
+    ): Dependency {
+        val dependency = Dependency()
+        dependency.groupId = SENTRY_GROUP_ID
+        dependency.artifactId = artifactId
+        dependency.version = version
+        dependency.type = "pom"
+        dependency.scope = "import"
+        return dependency
+    }
+}

--- a/src/test/java/io/sentry/unit/autoinstall/SentryAutoInstallTest.kt
+++ b/src/test/java/io/sentry/unit/autoinstall/SentryAutoInstallTest.kt
@@ -71,6 +71,26 @@ class SentryAutoInstallTest {
     }
 
     @Test
+    fun `installs sentry with managed version`() {
+        val sut = fixture.getSut()
+
+        val sentryVersion = sut.install(fixture.dependencies, fixture.resolvedArtifacts, "8.33.0")
+
+        assertEquals("8.33.0", sentryVersion)
+
+        assertTrue {
+            fixture.logger.capturedMessage ==
+                "Installing Sentry with version 8.33.0"
+        }
+
+        assertTrue(
+            fixture.dependencies.any {
+                it.groupId == "io.sentry" && it.artifactId == "sentry" && it.version == "8.33.0"
+            },
+        )
+    }
+
+    @Test
     fun `if sentry version cannot be resolved, don't install sentry and return null`() {
         val sut = fixture.getSut()
 

--- a/src/test/java/io/sentry/unit/autoinstall/SentryAutoInstallTest.kt
+++ b/src/test/java/io/sentry/unit/autoinstall/SentryAutoInstallTest.kt
@@ -42,7 +42,7 @@ class SentryAutoInstallTest {
     @Test
     fun `when sentry is already installed logs a message and does nothing`() {
         val sut = fixture.getSut(false, sentryVersion = "6.25.2")
-        val sentryVersion = sut.install(fixture.dependencies, fixture.resolvedArtifacts)
+        val sentryVersion = sut.install(fixture.dependencies, fixture.resolvedArtifacts, null)
 
         assertEquals("6.25.2", sentryVersion)
 
@@ -58,7 +58,7 @@ class SentryAutoInstallTest {
     fun `installs sentry with info message`() {
         val sut = fixture.getSut()
 
-        val sentryVersion = sut.install(fixture.dependencies, fixture.resolvedArtifacts)
+        val sentryVersion = sut.install(fixture.dependencies, fixture.resolvedArtifacts, null)
 
         assertEquals(SdkVersionInfo.getSentryVersion(), sentryVersion)
 
@@ -97,7 +97,7 @@ class SentryAutoInstallTest {
         Mockito.mockStatic(SdkVersionInfo::class.java).use { utilities ->
             utilities.`when`<String>(SdkVersionInfo::getSentryVersion).thenReturn(null)
 
-            val sentryVersion = sut.install(fixture.dependencies, fixture.resolvedArtifacts)
+            val sentryVersion = sut.install(fixture.dependencies, fixture.resolvedArtifacts, null)
 
             assertEquals(null, sentryVersion)
 


### PR DESCRIPTION
Use managed Sentry SDK versions from Maven dependency management when auto-installing Sentry dependencies.

When a project imported `sentry-bom` or `sentry-opentelemetry-bom` without declaring `io.sentry:sentry`, the plugin fell back to its bundled SDK version. That could install Sentry modules at a different version than the BOM selected. This now reads the managed Sentry version first and feeds it into the Sentry and integration installers, while preserving the existing behavior of using an already-resolved `io.sentry:sentry` dependency when present.