### PR TITLE
feat(auto-install): Auto-install sentry-opentelemetry-bom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Features
 
+- Auto-install `sentry-opentelemetry-bom` to align OpenTelemetry versions with the ones Sentry was tested against when a Sentry OpenTelemetry integration is used. Versions inherited from parents or other BOMs (e.g. Spring Boot) are aligned in place, while versions you pinned explicitly are left untouched. Disable with `<skipInstallOpenTelemetryBom>true</skipInstallOpenTelemetryBom>`.
 - add option to ignore source bundle upload failures ([#209](https://github.com/getsentry/sentry-maven-plugin/pull/209))
 
 ### Dependencies

--- a/src/main/java/io/sentry/SentryInstallerLifecycleParticipant.java
+++ b/src/main/java/io/sentry/SentryInstallerLifecycleParticipant.java
@@ -22,6 +22,7 @@ import io.sentry.autoinstall.graphql.GraphqlInstallStrategy;
 import io.sentry.autoinstall.jdbc.JdbcInstallStrategy;
 import io.sentry.autoinstall.log4j2.Log4j2InstallStrategy;
 import io.sentry.autoinstall.logback.LogbackInstallStrategy;
+import io.sentry.autoinstall.opentelemetry.OpenTelemetryBomInstaller;
 import io.sentry.autoinstall.quartz.QuartzInstallStrategy;
 import io.sentry.autoinstall.spring.*;
 import io.sentry.autoinstall.util.ManagedSentryVersionResolver;
@@ -73,6 +74,14 @@ public class SentryInstallerLifecycleParticipant extends AbstractMavenLifecycleP
   @SuppressWarnings("NullAway")
   @Inject
   private @NotNull BuildPluginManager pluginManager;
+
+  @SuppressWarnings("NullAway")
+  @Inject
+  private @NotNull org.apache.maven.project.ProjectBuilder projectBuilder;
+
+  @SuppressWarnings("NullAway")
+  @Inject
+  private @NotNull org.apache.maven.repository.RepositorySystem mavenRepositorySystem;
 
   private static final @NotNull org.slf4j.Logger logger =
       LoggerFactory.getLogger(SentryInstallerLifecycleParticipant.class);
@@ -137,6 +146,22 @@ public class SentryInstallerLifecycleParticipant extends AbstractMavenLifecycleP
             installer.install(dependencyList, resolvedArtifacts, autoInstallState);
           } catch (Throwable e) {
             logger.error("Unable to instantiate installer class: " + installerClass.getName(), e);
+          }
+        }
+
+        if (!pluginConfig.isSkipInstallOpenTelemetryBom()) {
+          try {
+            new OpenTelemetryBomInstaller()
+                .install(
+                    project,
+                    resolvedArtifacts,
+                    sentryVersion,
+                    projectBuilder,
+                    mavenRepositorySystem,
+                    session.getProjectBuildingRequest());
+          } catch (Throwable e) {
+            logger.error(
+                "Unable to install " + OpenTelemetryBomInstaller.SENTRY_OPENTELEMETRY_BOM_ID, e);
           }
         }
       } catch (Throwable t) {

--- a/src/main/java/io/sentry/autoinstall/opentelemetry/OpenTelemetryBomInstaller.java
+++ b/src/main/java/io/sentry/autoinstall/opentelemetry/OpenTelemetryBomInstaller.java
@@ -1,0 +1,272 @@
+package io.sentry.autoinstall.opentelemetry;
+
+import static io.sentry.Constants.SENTRY_GROUP_ID;
+import static io.sentry.Constants.SENTRY_OPENTELEMETRY_BOM_ARTIFACT_ID;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.building.ModelBuildingRequest;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.repository.RepositorySystem;
+import org.eclipse.aether.artifact.Artifact;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Aligns OpenTelemetry dependency versions with the versions Sentry was tested against, by
+ * expanding {@code io.sentry:sentry-opentelemetry-bom} and applying its managed OpenTelemetry
+ * versions to the project's {@code dependencyManagement}.
+ *
+ * <p>Maven resolves BOM imports during effective-model building, which happens before {@code
+ * afterProjectsRead}. A late-injected import-scope BOM is therefore a no-op. Instead we expand the
+ * BOM into concrete versions and: overwrite OpenTelemetry versions inherited from parents/other
+ * BOMs (e.g. Spring Boot) in place, add managed entries for OpenTelemetry artifacts that are not
+ * managed yet, and skip artifacts the user pinned explicitly (respecting their choice, warning when
+ * it differs from Sentry's tested version).
+ */
+public class OpenTelemetryBomInstaller {
+
+  public static final @NotNull String SENTRY_OPENTELEMETRY_BOM_ID =
+      SENTRY_OPENTELEMETRY_BOM_ARTIFACT_ID;
+  public static final @NotNull String SENTRY_OPENTELEMETRY_AGENT_ID = "sentry-opentelemetry-agent";
+  public static final @NotNull String SENTRY_OPENTELEMETRY_ARTIFACT_PREFIX =
+      "sentry-opentelemetry-";
+  public static final @NotNull String OPENTELEMETRY_GROUP_ID = "io.opentelemetry";
+
+  private final @NotNull Logger logger;
+
+  public OpenTelemetryBomInstaller() {
+    this(LoggerFactory.getLogger(OpenTelemetryBomInstaller.class));
+  }
+
+  public OpenTelemetryBomInstaller(final @NotNull Logger logger) {
+    this.logger = logger;
+  }
+
+  public void install(
+      final @NotNull MavenProject project,
+      final @NotNull List<Artifact> resolvedArtifacts,
+      final @NotNull String sentryVersion,
+      final @NotNull ProjectBuilder projectBuilder,
+      final @NotNull RepositorySystem repositorySystem,
+      final @NotNull ProjectBuildingRequest baseRequest) {
+
+    if (!hasEligibleOpenTelemetryDependency(resolvedArtifacts)) {
+      logger.info(
+          SENTRY_OPENTELEMETRY_BOM_ID
+              + " won't be installed because no Sentry OpenTelemetry dependency was found");
+      return;
+    }
+
+    if (isBomAlreadyManaged(project)) {
+      logger.info(
+          SENTRY_OPENTELEMETRY_BOM_ID
+              + " won't be installed because it was already installed directly");
+      return;
+    }
+
+    final @NotNull Map<String, String> bomVersions =
+        expandBom(project, sentryVersion, projectBuilder, repositorySystem, baseRequest);
+
+    if (bomVersions.isEmpty()) {
+      logger.info(
+          SENTRY_OPENTELEMETRY_BOM_ID
+              + " won't be installed because its OpenTelemetry versions could not be resolved");
+      return;
+    }
+
+    apply(project, bomVersions);
+  }
+
+  /**
+   * Returns true if the project (transitively) uses a Sentry OpenTelemetry integration that is
+   * managed by the BOM. The standalone agent fat jar and the BOM itself are excluded.
+   */
+  public static boolean hasEligibleOpenTelemetryDependency(
+      final @NotNull List<Artifact> resolvedArtifacts) {
+    return resolvedArtifacts.stream()
+        .anyMatch(
+            (dep) ->
+                dep.getGroupId().equals(SENTRY_GROUP_ID)
+                    && dep.getArtifactId().startsWith(SENTRY_OPENTELEMETRY_ARTIFACT_PREFIX)
+                    && !dep.getArtifactId().equals(SENTRY_OPENTELEMETRY_BOM_ID)
+                    && !dep.getArtifactId().equals(SENTRY_OPENTELEMETRY_AGENT_ID));
+  }
+
+  /**
+   * Returns true if the project already imports {@code sentry-opentelemetry-bom} in its own {@code
+   * dependencyManagement}. Import-scope BOMs are consumed during effective-model building and are
+   * not resolved artifacts, so this is checked against the authored model.
+   */
+  public static boolean isBomAlreadyManaged(final @NotNull MavenProject project) {
+    final @Nullable Model original = project.getOriginalModel();
+    if (original == null || original.getDependencyManagement() == null) {
+      return false;
+    }
+    return original.getDependencyManagement().getDependencies().stream()
+        .anyMatch(
+            (dep) ->
+                dep.getGroupId().equals(SENTRY_GROUP_ID)
+                    && dep.getArtifactId().equals(SENTRY_OPENTELEMETRY_BOM_ID));
+  }
+
+  /**
+   * Resolves {@code io.sentry:sentry-opentelemetry-bom:<sentryVersion>} and returns its managed
+   * OpenTelemetry versions as a {@code groupId:artifactId -> version} map. Returns an empty map if
+   * the BOM cannot be resolved or built (e.g. not published for this version).
+   */
+  @NotNull
+  Map<String, String> expandBom(
+      final @NotNull MavenProject project,
+      final @NotNull String sentryVersion,
+      final @NotNull ProjectBuilder projectBuilder,
+      final @NotNull RepositorySystem repositorySystem,
+      final @NotNull ProjectBuildingRequest baseRequest) {
+    final @NotNull Map<String, String> versions = new HashMap<>();
+    try {
+      final org.apache.maven.artifact.@NotNull Artifact bomArtifact =
+          repositorySystem.createProjectArtifact(
+              SENTRY_GROUP_ID, SENTRY_OPENTELEMETRY_BOM_ID, sentryVersion);
+
+      final @NotNull ProjectBuildingRequest request =
+          new DefaultProjectBuildingRequest(baseRequest);
+      request.setProject(null);
+      request.setResolveDependencies(false);
+      // resolve the BOM using the project's own repositories, not just the session defaults
+      request.setRemoteRepositories(project.getRemoteArtifactRepositories());
+      request.setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL);
+
+      final @NotNull MavenProject bomProject =
+          projectBuilder.build(bomArtifact, true, request).getProject();
+
+      final @Nullable DependencyManagement dependencyManagement =
+          bomProject.getDependencyManagement();
+      if (dependencyManagement != null) {
+        for (final @NotNull Dependency dependency : dependencyManagement.getDependencies()) {
+          if (OPENTELEMETRY_GROUP_ID.equals(dependency.getGroupId())
+              && dependency.getVersion() != null) {
+            versions.put(
+                key(dependency.getGroupId(), dependency.getArtifactId()), dependency.getVersion());
+          }
+        }
+      }
+    } catch (Throwable t) {
+      logger.info(
+          "Unable to resolve "
+              + SENTRY_OPENTELEMETRY_BOM_ID
+              + ":"
+              + sentryVersion
+              + ", skipping OpenTelemetry version alignment: "
+              + t.getMessage());
+    }
+    return versions;
+  }
+
+  void apply(final @NotNull MavenProject project, final @NotNull Map<String, String> bomVersions) {
+    final @NotNull Map<String, String> userPinned = userPinnedVersions(project.getOriginalModel());
+
+    final @NotNull Model model = project.getModel();
+    @Nullable DependencyManagement dependencyManagement = model.getDependencyManagement();
+    if (dependencyManagement == null) {
+      dependencyManagement = new DependencyManagement();
+      model.setDependencyManagement(dependencyManagement);
+    }
+
+    final @NotNull Map<String, Dependency> managedByKey = new HashMap<>();
+    for (final @NotNull Dependency dependency : dependencyManagement.getDependencies()) {
+      managedByKey.putIfAbsent(
+          key(dependency.getGroupId(), dependency.getArtifactId()), dependency);
+    }
+
+    for (final Map.@NotNull Entry<String, String> entry : bomVersions.entrySet()) {
+      final @NotNull String gaKey = entry.getKey();
+      final @NotNull String bomVersion = entry.getValue();
+
+      if (userPinned.containsKey(gaKey)) {
+        final @NotNull String pinnedVersion = userPinned.get(gaKey);
+        if (!pinnedVersion.contains("${") && !pinnedVersion.equals(bomVersion)) {
+          logger.warn(
+              gaKey
+                  + " is pinned to "
+                  + pinnedVersion
+                  + " in your project, but Sentry was tested with "
+                  + bomVersion
+                  + ". Leaving your version in place. Remove the pin (or import "
+                  + SENTRY_OPENTELEMETRY_BOM_ID
+                  + " first) to let Sentry manage it.");
+        }
+        continue;
+      }
+
+      final @Nullable Dependency existing = managedByKey.get(gaKey);
+      if (existing != null) {
+        if (!bomVersion.equals(existing.getVersion())) {
+          logger.info(
+              "Aligning "
+                  + gaKey
+                  + " from "
+                  + existing.getVersion()
+                  + " to "
+                  + bomVersion
+                  + " ("
+                  + SENTRY_OPENTELEMETRY_BOM_ID
+                  + ")");
+          existing.setVersion(bomVersion);
+        }
+      } else {
+        final @NotNull Dependency managed = new Dependency();
+        final int separator = gaKey.indexOf(':');
+        managed.setGroupId(gaKey.substring(0, separator));
+        managed.setArtifactId(gaKey.substring(separator + 1));
+        managed.setVersion(bomVersion);
+        dependencyManagement.addDependency(managed);
+        logger.info(
+            "Managing " + gaKey + ":" + bomVersion + " (" + SENTRY_OPENTELEMETRY_BOM_ID + ")");
+      }
+    }
+  }
+
+  /**
+   * Versions the user declared explicitly, read from the authored (un-flattened) model: entries in
+   * the project's own {@code dependencyManagement} and direct dependencies with an explicit
+   * version. Inherited or BOM-sourced versions are not included.
+   */
+  static @NotNull Map<String, String> userPinnedVersions(final @Nullable Model originalModel) {
+    final @NotNull Map<String, String> pinned = new HashMap<>();
+    if (originalModel == null) {
+      return pinned;
+    }
+    final @Nullable DependencyManagement dependencyManagement =
+        originalModel.getDependencyManagement();
+    if (dependencyManagement != null) {
+      for (final @NotNull Dependency dependency : dependencyManagement.getDependencies()) {
+        if (dependency.getVersion() != null) {
+          pinned.put(
+              key(dependency.getGroupId(), dependency.getArtifactId()), dependency.getVersion());
+        }
+      }
+    }
+    for (final @NotNull Dependency dependency : originalModel.getDependencies()) {
+      if (dependency.getVersion() != null) {
+        // a direct dependency with an explicit version wins over dependencyManagement
+        pinned.put(
+            key(dependency.getGroupId(), dependency.getArtifactId()), dependency.getVersion());
+      }
+    }
+    return pinned;
+  }
+
+  private static @NotNull String key(
+      final @NotNull String groupId, final @NotNull String artifactId) {
+    return groupId + ":" + artifactId;
+  }
+}

--- a/src/main/java/io/sentry/config/ConfigParser.java
+++ b/src/main/java/io/sentry/config/ConfigParser.java
@@ -15,6 +15,8 @@ public class ConfigParser {
 
   private static final @NotNull String SKIP_ALL_FLAG = "skip";
   private static final @NotNull String SKIP_AUTO_INSTALL_FLAG = "skipAutoInstall";
+  private static final @NotNull String SKIP_INSTALL_OPENTELEMETRY_BOM_FLAG =
+      "skipInstallOpenTelemetryBom";
   private static final @NotNull String SKIP_TELEMETRY_FLAG = "skipTelemetry";
   private static final @NotNull String SKIP_REPORT_DEPENDENCIES_FLAG = "skipReportDependencies";
   private static final @NotNull String SKIP_SOURCE_BUNDLE_FLAG = "skipSourceBundle";
@@ -55,6 +57,11 @@ public class ConfigParser {
       pluginConfig.setSkipAutoInstall(
           dom.getChild(SKIP_AUTO_INSTALL_FLAG) != null
               && Boolean.parseBoolean(dom.getChild(SKIP_AUTO_INSTALL_FLAG).getValue()));
+
+      pluginConfig.setSkipInstallOpenTelemetryBom(
+          dom.getChild(SKIP_INSTALL_OPENTELEMETRY_BOM_FLAG) != null
+              && Boolean.parseBoolean(
+                  dom.getChild(SKIP_INSTALL_OPENTELEMETRY_BOM_FLAG).getValue()));
 
       pluginConfig.setSkipTelemetry(
           dom.getChild(SKIP_TELEMETRY_FLAG) != null

--- a/src/main/java/io/sentry/config/PluginConfig.java
+++ b/src/main/java/io/sentry/config/PluginConfig.java
@@ -10,6 +10,8 @@ public class PluginConfig {
   public static final @NotNull String DEFAULT_SKIP_REPORT_DEPENDENCIES_STRING = "false";
   public static final boolean DEFAULT_SKIP_AUTO_INSTALL = false;
   public static final @NotNull String DEFAULT_SKIP_AUTO_INSTALL_STRING = "false";
+  public static final boolean DEFAULT_SKIP_INSTALL_OPENTELEMETRY_BOM = false;
+  public static final @NotNull String DEFAULT_SKIP_INSTALL_OPENTELEMETRY_BOM_STRING = "false";
   public static final boolean DEFAULT_SKIP_SOURCE_BUNDLE = false;
   public static final @NotNull String DEFAULT_SKIP_SOURCE_BUNDLE_STRING = "false";
   public static final boolean DEFAULT_IGNORE_SOURCE_BUNDLE_UPLOAD_FAILURE = false;
@@ -27,6 +29,7 @@ public class PluginConfig {
 
   private boolean skip = DEFAULT_SKIP;
   private boolean skipAutoInstall = DEFAULT_SKIP_AUTO_INSTALL;
+  private boolean skipInstallOpenTelemetryBom = DEFAULT_SKIP_INSTALL_OPENTELEMETRY_BOM;
   private boolean skipTelemetry = DEFAULT_SKIP_TELEMETRY;
   private boolean skipReportDependencies = DEFAULT_SKIP_REPORT_DEPENDENCIES;
   private boolean skipSourceBundle = DEFAULT_SKIP_SOURCE_BUNDLE;
@@ -102,6 +105,14 @@ public class PluginConfig {
 
   public boolean isSkipAutoInstall() {
     return skipAutoInstall || skip;
+  }
+
+  public void setSkipInstallOpenTelemetryBom(final boolean skipInstallOpenTelemetryBom) {
+    this.skipInstallOpenTelemetryBom = skipInstallOpenTelemetryBom;
+  }
+
+  public boolean isSkipInstallOpenTelemetryBom() {
+    return skipInstallOpenTelemetryBom || skipAutoInstall || skip;
   }
 
   public boolean isSkipTelemetry() {

--- a/src/main/java/io/sentry/telemetry/SentryTelemetryService.java
+++ b/src/main/java/io/sentry/telemetry/SentryTelemetryService.java
@@ -103,6 +103,9 @@ public class SentryTelemetryService {
                   "SENTRY_autoInstallation_enabled",
                   String.valueOf(!pluginConfig.isSkipAutoInstall()));
               options.setTag(
+                  "SENTRY_installOpenTelemetryBom",
+                  String.valueOf(!pluginConfig.isSkipInstallOpenTelemetryBom()));
+              options.setTag(
                   "SENTRY_includeDependenciesReport",
                   String.valueOf(!pluginConfig.isSkipReportDependencies()));
               options.setTag(

--- a/src/test/java/io/sentry/autoinstall/opentelemetry/OpenTelemetryBomInstallerTest.kt
+++ b/src/test/java/io/sentry/autoinstall/opentelemetry/OpenTelemetryBomInstallerTest.kt
@@ -1,0 +1,188 @@
+package io.sentry.autoinstall.opentelemetry
+
+import io.sentry.unit.fakes.CapturingTestLogger
+import org.apache.maven.model.Dependency
+import org.apache.maven.model.DependencyManagement
+import org.apache.maven.model.Model
+import org.apache.maven.project.MavenProject
+import org.eclipse.aether.artifact.Artifact
+import org.eclipse.aether.artifact.DefaultArtifact
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class OpenTelemetryBomInstallerTest {
+    private fun managed(
+        groupId: String,
+        artifactId: String,
+        version: String?,
+    ) = Dependency().apply {
+        this.groupId = groupId
+        this.artifactId = artifactId
+        this.version = version
+    }
+
+    private fun project(
+        effective: List<Dependency> = emptyList(),
+        userManaged: List<Dependency> = emptyList(),
+        userDirect: List<Dependency> = emptyList(),
+    ): MavenProject {
+        val model =
+            Model().apply {
+                dependencyManagement = DependencyManagement().apply { effective.forEach { addDependency(it) } }
+            }
+        val original =
+            Model().apply {
+                dependencyManagement = DependencyManagement().apply { userManaged.forEach { addDependency(it) } }
+                userDirect.forEach { addDependency(it) }
+            }
+        return MavenProject(model).apply { originalModel = original }
+    }
+
+    private fun managedVersion(
+        project: MavenProject,
+        artifactId: String,
+    ): String? =
+        project.model.dependencyManagement.dependencies
+            .firstOrNull { it.groupId == "io.opentelemetry" && it.artifactId == artifactId }
+            ?.version
+
+    @Test
+    fun `overwrites inherited opentelemetry version in place`() {
+        val project = project(effective = listOf(managed("io.opentelemetry", "opentelemetry-sdk", "1.43.0")))
+        val logger = CapturingTestLogger()
+
+        OpenTelemetryBomInstaller(logger).apply(project, mapOf("io.opentelemetry:opentelemetry-sdk" to "1.57.0"))
+
+        assertEquals("1.57.0", managedVersion(project, "opentelemetry-sdk"))
+        assertTrue { logger.capturedMessage?.contains("Aligning") == true }
+    }
+
+    @Test
+    fun `adds managed entry when opentelemetry artifact is not managed`() {
+        val project = project()
+
+        OpenTelemetryBomInstaller(CapturingTestLogger())
+            .apply(project, mapOf("io.opentelemetry:opentelemetry-sdk" to "1.57.0"))
+
+        assertEquals("1.57.0", managedVersion(project, "opentelemetry-sdk"))
+    }
+
+    @Test
+    fun `skips and warns when user pinned a different version in dependencyManagement`() {
+        val project =
+            project(
+                effective = listOf(managed("io.opentelemetry", "opentelemetry-sdk", "1.39.0")),
+                userManaged = listOf(managed("io.opentelemetry", "opentelemetry-sdk", "1.39.0")),
+            )
+        val logger = CapturingTestLogger()
+
+        OpenTelemetryBomInstaller(logger).apply(project, mapOf("io.opentelemetry:opentelemetry-sdk" to "1.57.0"))
+
+        assertEquals("1.39.0", managedVersion(project, "opentelemetry-sdk"))
+        assertTrue { logger.capturedMessage?.contains("is pinned to 1.39.0") == true }
+    }
+
+    @Test
+    fun `skips user direct dependency with explicit version`() {
+        val project =
+            project(
+                userDirect = listOf(managed("io.opentelemetry", "opentelemetry-sdk", "1.39.0")),
+            )
+
+        OpenTelemetryBomInstaller(CapturingTestLogger())
+            .apply(project, mapOf("io.opentelemetry:opentelemetry-sdk" to "1.57.0"))
+
+        assertNull(managedVersion(project, "opentelemetry-sdk"))
+    }
+
+    @Test
+    fun `does not warn when user pin matches bom version`() {
+        val project =
+            project(userManaged = listOf(managed("io.opentelemetry", "opentelemetry-sdk", "1.57.0")))
+        val logger = CapturingTestLogger()
+
+        OpenTelemetryBomInstaller(logger).apply(project, mapOf("io.opentelemetry:opentelemetry-sdk" to "1.57.0"))
+
+        assertNull(logger.capturedMessage)
+    }
+
+    @Test
+    fun `does not warn when user pin uses a property placeholder`() {
+        val project =
+            project(userManaged = listOf(managed("io.opentelemetry", "opentelemetry-sdk", "\${otel.version}")))
+        val logger = CapturingTestLogger()
+
+        OpenTelemetryBomInstaller(logger).apply(project, mapOf("io.opentelemetry:opentelemetry-sdk" to "1.57.0"))
+
+        assertNull(logger.capturedMessage)
+    }
+
+    @Test
+    fun `userPinnedVersions reads managed and direct explicit versions only`() {
+        val original =
+            Model().apply {
+                dependencyManagement =
+                    DependencyManagement().apply { addDependency(managed("io.opentelemetry", "opentelemetry-api", "1.39.0")) }
+                addDependency(managed("io.opentelemetry", "opentelemetry-sdk", "1.40.0"))
+                addDependency(managed("io.opentelemetry", "opentelemetry-context", null))
+            }
+
+        val pinned = OpenTelemetryBomInstaller.userPinnedVersions(original)
+
+        assertEquals("1.39.0", pinned["io.opentelemetry:opentelemetry-api"])
+        assertEquals("1.40.0", pinned["io.opentelemetry:opentelemetry-sdk"])
+        assertFalse { pinned.containsKey("io.opentelemetry:opentelemetry-context") }
+    }
+
+    @Test
+    fun `eligibility detects sentry opentelemetry dependency excluding bom and agent`() {
+        assertTrue {
+            OpenTelemetryBomInstaller.hasEligibleOpenTelemetryDependency(
+                listOf(artifact("io.sentry", "sentry-opentelemetry-agentless", "8.34.1")),
+            )
+        }
+        assertFalse {
+            OpenTelemetryBomInstaller.hasEligibleOpenTelemetryDependency(
+                listOf(artifact("io.sentry", "sentry-opentelemetry-agent", "8.34.1")),
+            )
+        }
+        assertFalse {
+            OpenTelemetryBomInstaller.hasEligibleOpenTelemetryDependency(
+                listOf(artifact("io.sentry", "sentry-opentelemetry-bom", "8.34.1")),
+            )
+        }
+        assertFalse {
+            OpenTelemetryBomInstaller.hasEligibleOpenTelemetryDependency(
+                listOf(artifact("io.sentry", "sentry", "8.34.1")),
+            )
+        }
+    }
+
+    @Test
+    fun `detects bom already managed via original model`() {
+        val withBom =
+            project(
+                userManaged =
+                    listOf(
+                        Dependency().apply {
+                            groupId = "io.sentry"
+                            artifactId = "sentry-opentelemetry-bom"
+                            version = "8.34.1"
+                            type = "pom"
+                            scope = "import"
+                        },
+                    ),
+            )
+        assertTrue { OpenTelemetryBomInstaller.isBomAlreadyManaged(withBom) }
+        assertFalse { OpenTelemetryBomInstaller.isBomAlreadyManaged(project()) }
+    }
+
+    private fun artifact(
+        groupId: String,
+        artifactId: String,
+        version: String,
+    ): Artifact = DefaultArtifact(groupId, artifactId, null, version)
+}

--- a/src/test/java/io/sentry/integration/autoinstall/opentelemetry/OpenTelemetryBomAutoInstallTestIT.kt
+++ b/src/test/java/io/sentry/integration/autoinstall/opentelemetry/OpenTelemetryBomAutoInstallTestIT.kt
@@ -1,0 +1,158 @@
+package io.sentry.integration.autoinstall.opentelemetry
+
+import io.sentry.autoinstall.util.SdkVersionInfo
+import io.sentry.integration.installMavenWrapper
+import org.apache.maven.it.Verifier
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.StandardOpenOption
+import kotlin.io.path.Path
+
+class OpenTelemetryBomAutoInstallTestIT {
+    @TempDir
+    lateinit var file: File
+
+    private val sentryVersion: String = SdkVersionInfo.getSentryVersion()!!
+    private val bomOtelVersion = "1.40.0"
+
+    @BeforeEach
+    fun setup() {
+        installMavenWrapper(file, "3.8.6")
+        val repoDir = File(file, "repo")
+        writeFakeOpenTelemetryBom(repoDir, sentryVersion, bomOtelVersion)
+    }
+
+    @AfterEach
+    fun cleanup() {
+        // The fake BOM served from the file repo is cached into the local repo during the build.
+        // Remove it so it can't shadow the real artifact in later builds.
+        val localRepo =
+            System.getProperty("maven.repo.local")
+                ?: (System.getProperty("user.home") + "/.m2/repository")
+        File(localRepo, "io/sentry/sentry-opentelemetry-bom").deleteRecursively()
+    }
+
+    private fun writePom(content: String): Verifier {
+        Files.write(Path("${file.absolutePath}/pom.xml"), content.toByteArray(), StandardOpenOption.CREATE)
+        return Verifier(file.absolutePath).apply {
+            isAutoclean = false
+            deleteDirectory("target")
+        }
+    }
+
+    private fun repoUrl(): String = File(file, "repo").toURI().toString()
+
+    @Test
+    fun `aligns OpenTelemetry versions inherited from spring-boot-starter-parent`() {
+        val verifier =
+            writePom(
+                openTelemetryPom(
+                    repoUrl = repoUrl(),
+                    sentryVersion = sentryVersion,
+                    useSpringBootParent = true,
+                ),
+            )
+
+        verifier.executeGoal("install")
+
+        verifier.verifyFilePresent("target/lib/opentelemetry-sdk-$bomOtelVersion.jar")
+        verifier.verifyFileNotPresent("target/lib/opentelemetry-sdk-1.43.0.jar")
+        verifier.resetStreams()
+    }
+
+    @Test
+    fun `aligns transitive OpenTelemetry versions without spring boot`() {
+        val verifier =
+            writePom(openTelemetryPom(repoUrl = repoUrl(), sentryVersion = sentryVersion))
+
+        verifier.executeGoal("install")
+
+        verifier.verifyFilePresent("target/lib/opentelemetry-sdk-$bomOtelVersion.jar")
+        verifier.verifyFileNotPresent("target/lib/opentelemetry-sdk-1.57.0.jar")
+        verifier.resetStreams()
+    }
+
+    @Test
+    fun `respects a user pinned OpenTelemetry version and warns`() {
+        val verifier =
+            writePom(
+                openTelemetryPom(
+                    repoUrl = repoUrl(),
+                    sentryVersion = sentryVersion,
+                    userPinnedOtelVersion = "1.39.0",
+                ),
+            )
+
+        verifier.executeGoal("install")
+
+        verifier.verifyFilePresent("target/lib/opentelemetry-sdk-1.39.0.jar")
+        verifier.verifyFileNotPresent("target/lib/opentelemetry-sdk-$bomOtelVersion.jar")
+        verifier.verifyTextInLog("opentelemetry-sdk is pinned to 1.39.0")
+        verifier.resetStreams()
+    }
+
+    @Test
+    fun `does nothing when skipInstallOpenTelemetryBom is true`() {
+        val verifier =
+            writePom(
+                openTelemetryPom(
+                    repoUrl = repoUrl(),
+                    sentryVersion = sentryVersion,
+                    pluginConfiguration =
+                        """
+                        <configuration>
+                            <skipInstallOpenTelemetryBom>true</skipInstallOpenTelemetryBom>
+                        </configuration>
+                        """.trimIndent(),
+                ),
+            )
+
+        verifier.executeGoal("install")
+
+        verifier.verifyFilePresent("target/lib/opentelemetry-sdk-1.57.0.jar")
+        verifier.verifyFileNotPresent("target/lib/opentelemetry-sdk-$bomOtelVersion.jar")
+        verifier.resetStreams()
+    }
+
+    @Test
+    fun `does nothing for sentry-opentelemetry-agent`() {
+        val verifier =
+            writePom(
+                openTelemetryPom(
+                    repoUrl = repoUrl(),
+                    sentryVersion = sentryVersion,
+                    otelDependency = "sentry-opentelemetry-agent",
+                ),
+            )
+
+        verifier.executeGoal("install")
+
+        verifier.verifyTextInLog(
+            "sentry-opentelemetry-bom won't be installed because no Sentry OpenTelemetry dependency was found",
+        )
+        verifier.resetStreams()
+    }
+
+    @Test
+    fun `does nothing when bom is already imported`() {
+        val verifier =
+            writePom(
+                openTelemetryPom(
+                    repoUrl = repoUrl(),
+                    sentryVersion = sentryVersion,
+                    importBom = true,
+                ),
+            )
+
+        verifier.executeGoal("install")
+
+        verifier.verifyTextInLog(
+            "sentry-opentelemetry-bom won't be installed because it was already installed directly",
+        )
+        verifier.resetStreams()
+    }
+}

--- a/src/test/java/io/sentry/integration/autoinstall/opentelemetry/PomUtils.kt
+++ b/src/test/java/io/sentry/integration/autoinstall/opentelemetry/PomUtils.kt
@@ -1,0 +1,176 @@
+package io.sentry.integration.autoinstall.opentelemetry
+
+import java.io.File
+
+/**
+ * Writes a fake `io.sentry:sentry-opentelemetry-bom` into a local file repository under [repoDir].
+ * The BOM imports the real `io.opentelemetry:opentelemetry-bom:[otelVersion]` (resolved from Maven
+ * Central), so the version alignment exercised by the tests is genuine.
+ */
+fun writeFakeOpenTelemetryBom(
+    repoDir: File,
+    sentryVersion: String,
+    otelVersion: String,
+) {
+    val pom =
+        File(
+            repoDir,
+            "io/sentry/sentry-opentelemetry-bom/$sentryVersion/sentry-opentelemetry-bom-$sentryVersion.pom",
+        )
+    pom.parentFile.mkdirs()
+    pom.writeText(
+        """
+        <project xmlns="http://maven.apache.org/POM/4.0.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+          <modelVersion>4.0.0</modelVersion>
+          <groupId>io.sentry</groupId>
+          <artifactId>sentry-opentelemetry-bom</artifactId>
+          <version>$sentryVersion</version>
+          <packaging>pom</packaging>
+          <dependencyManagement>
+            <dependencies>
+              <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>$otelVersion</version>
+                <type>pom</type>
+                <scope>import</scope>
+              </dependency>
+            </dependencies>
+          </dependencyManagement>
+        </project>
+        """.trimIndent(),
+    )
+}
+
+/**
+ * Builds a POM for the OpenTelemetry BOM auto-install integration tests.
+ *
+ * @param repoUrl file URL of the repository that serves the fake sentry-opentelemetry-bom
+ * @param useSpringBootParent inherit OpenTelemetry version management from spring-boot-starter-parent
+ * @param otelDependency the Sentry OpenTelemetry dependency to declare (agentless by default)
+ * @param userPinnedOtelVersion when set, pins io.opentelemetry:opentelemetry-sdk in the project's
+ *   own dependencyManagement
+ * @param importBom when true, the project imports the sentry-opentelemetry-bom itself
+ * @param pluginConfiguration optional `<configuration>` block for the Sentry plugin
+ */
+fun openTelemetryPom(
+    repoUrl: String,
+    sentryVersion: String,
+    useSpringBootParent: Boolean = false,
+    otelDependency: String = "sentry-opentelemetry-agentless",
+    userPinnedOtelVersion: String? = null,
+    importBom: Boolean = false,
+    pluginConfiguration: String = "",
+): String {
+    val parent =
+        if (useSpringBootParent) {
+            """
+            <parent>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-parent</artifactId>
+                <version>3.4.1</version>
+                <relativePath/>
+            </parent>
+            """.trimIndent()
+        } else {
+            ""
+        }
+
+    val managedDeps =
+        buildString {
+            if (userPinnedOtelVersion != null) {
+                append(
+                    """
+                    <dependency>
+                        <groupId>io.opentelemetry</groupId>
+                        <artifactId>opentelemetry-sdk</artifactId>
+                        <version>$userPinnedOtelVersion</version>
+                    </dependency>
+                    """.trimIndent(),
+                )
+            }
+            if (importBom) {
+                append(
+                    """
+                    <dependency>
+                        <groupId>io.sentry</groupId>
+                        <artifactId>sentry-opentelemetry-bom</artifactId>
+                        <version>$sentryVersion</version>
+                        <type>pom</type>
+                        <scope>import</scope>
+                    </dependency>
+                    """.trimIndent(),
+                )
+            }
+        }
+
+    val dependencyManagement =
+        if (managedDeps.isNotEmpty()) {
+            "<dependencyManagement><dependencies>$managedDeps</dependencies></dependencyManagement>"
+        } else {
+            ""
+        }
+
+    return """
+        <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+            <modelVersion>4.0.0</modelVersion>
+            $parent
+            <groupId>io.sentry.autoinstall</groupId>
+            <artifactId>installotelbom</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <packaging>jar</packaging>
+
+            <properties>
+                <maven.compiler.source>17</maven.compiler.source>
+                <maven.compiler.target>17</maven.compiler.target>
+                <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+            </properties>
+
+            <repositories>
+                <repository>
+                    <id>fake-sentry-bom-repo</id>
+                    <url>$repoUrl</url>
+                </repository>
+            </repositories>
+
+            $dependencyManagement
+
+            <dependencies>
+                <dependency>
+                    <groupId>io.sentry</groupId>
+                    <artifactId>$otelDependency</artifactId>
+                    <version>$sentryVersion</version>
+                </dependency>
+            </dependencies>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.sentry</groupId>
+                        <artifactId>sentry-maven-plugin</artifactId>
+                        <version>1.0-SNAPSHOT</version>
+                        <extensions>true</extensions>
+                        $pluginConfiguration
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>install</phase>
+                                <goals>
+                                    <goal>copy-dependencies</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>target/lib</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </project>
+        """.trimIndent()
+}


### PR DESCRIPTION
Builds on top of #265.

## What

Auto-installs `io.sentry:sentry-opentelemetry-bom` to align OpenTelemetry dependency versions with the versions Sentry was tested against, whenever a project uses a Sentry OpenTelemetry integration (excluding the standalone `sentry-opentelemetry-agent` and the BOM itself).

## Why the mechanism differs from the Gradle plugin

Maven resolves BOM imports during effective-model building, which happens **before** the plugin's `afterProjectsRead` hook. A late-injected import-scope BOM is therefore a no-op (verified experimentally). Instead the plugin:

1. Resolves `sentry-opentelemetry-bom` at the managed Sentry version (via #265's `ManagedSentryVersionResolver`, with SDK fallback) and expands it into concrete OpenTelemetry versions using `ProjectBuilder`.
2. Applies them to the project's `dependencyManagement`:
   - **overwrite in place** OpenTelemetry versions inherited from a parent/other BOM (e.g. Spring Boot),
   - **add** managed entries for unmanaged OpenTelemetry artifacts,
   - **skip** versions the user pinned explicitly (own `<dependencyManagement>` or explicit direct `<version>`), warning when they differ from Sentry's tested version.

This wins over Spring Boot dependency management (both `spring-boot-starter-parent` and imported `spring-boot-dependencies`) without turning transitive artifacts into direct dependencies.

## Config

Opt out with `<skipInstallOpenTelemetryBom>true</skipInstallOpenTelemetryBom>`. Adds a `SENTRY_installOpenTelemetryBom` telemetry tag.

## Notes

- Self-skips gracefully until `sentry-opentelemetry-bom` is published for the resolved Sentry version.

## Tests

- Unit: `OpenTelemetryBomInstallerTest` (detection, expand, skip/overwrite/add, user-pin respect + warning).
- Integration: `OpenTelemetryBomAutoInstallTestIT` — Spring Boot parent alignment, transitive alignment, user-pin respect + warn, disabled flag, agent no-op, BOM-already-imported.

Co-authored with Claude.
