### PR TITLE
feat(auto-install): Fail the build on OpenTelemetry version downgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Fail the build when OpenTelemetry dependencies are downgraded below the versions Sentry's `sentry-opentelemetry-*` artifacts require (e.g. by Spring Boot's dependency management), with guidance to import `sentry-opentelemetry-bom`. Disable with `<skipValidateOpenTelemetryVersions>true</skipValidateOpenTelemetryVersions>`.
+
 ### Fixes
 
 - Use imported Sentry BOM versions for auto-installed dependencies ([#265](https://github.com/getsentry/sentry-maven-plugin/pull/265))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Features
 
-- Fail the build when OpenTelemetry dependencies are downgraded below the versions Sentry's `sentry-opentelemetry-*` artifacts require (e.g. by Spring Boot's dependency management), with guidance to import `sentry-opentelemetry-bom`. Disable with `<skipValidateOpenTelemetryVersions>true</skipValidateOpenTelemetryVersions>`.
+- Fail the build when OpenTelemetry dependencies are downgraded below the versions Sentry's `sentry-opentelemetry-*` artifacts require ([#268](https://github.com/getsentry/sentry-maven-plugin/pull/268))
+  - The `sentry-opentelemetry-*` artifacts are built against specific OpenTelemetry versions. When another dependency management mechanism (most commonly Spring Boot's `spring-boot-dependencies` BOM) forces OpenTelemetry below the version Sentry's integration requires, running against those downgraded versions can cause `ClassNotFoundException` / `NoSuchMethodError` at runtime. The plugin now detects this downgrade and fails the build early with guidance on how to fix it.
+  - You may disable this check by setting `<skipValidateOpenTelemetryVersions>true</skipValidateOpenTelemetryVersions>` in the plugin configuration.
 
 ### Fixes
 

--- a/src/main/java/io/sentry/SentryInstallerLifecycleParticipant.java
+++ b/src/main/java/io/sentry/SentryInstallerLifecycleParticipant.java
@@ -22,6 +22,7 @@ import io.sentry.autoinstall.graphql.GraphqlInstallStrategy;
 import io.sentry.autoinstall.jdbc.JdbcInstallStrategy;
 import io.sentry.autoinstall.log4j2.Log4j2InstallStrategy;
 import io.sentry.autoinstall.logback.LogbackInstallStrategy;
+import io.sentry.autoinstall.opentelemetry.OpenTelemetryVersionChecker;
 import io.sentry.autoinstall.quartz.QuartzInstallStrategy;
 import io.sentry.autoinstall.spring.*;
 import io.sentry.autoinstall.util.ManagedSentryVersionResolver;
@@ -73,6 +74,14 @@ public class SentryInstallerLifecycleParticipant extends AbstractMavenLifecycleP
   @SuppressWarnings("NullAway")
   @Inject
   private @NotNull BuildPluginManager pluginManager;
+
+  @SuppressWarnings("NullAway")
+  @Inject
+  private @NotNull org.apache.maven.project.ProjectBuilder projectBuilder;
+
+  @SuppressWarnings("NullAway")
+  @Inject
+  private @NotNull org.apache.maven.repository.RepositorySystem mavenRepositorySystem;
 
   private static final @NotNull org.slf4j.Logger logger =
       LoggerFactory.getLogger(SentryInstallerLifecycleParticipant.class);
@@ -138,6 +147,17 @@ public class SentryInstallerLifecycleParticipant extends AbstractMavenLifecycleP
           } catch (Throwable e) {
             logger.error("Unable to instantiate installer class: " + installerClass.getName(), e);
           }
+        }
+
+        if (!pluginConfig.isSkipValidateOpenTelemetryVersions()) {
+          new OpenTelemetryVersionChecker()
+              .check(
+                  project,
+                  resolvedArtifacts,
+                  sentryVersion,
+                  projectBuilder,
+                  mavenRepositorySystem,
+                  session.getProjectBuildingRequest());
         }
       } catch (Throwable t) {
         SentryTelemetryService.getInstance().captureError(t, "auto-install");

--- a/src/main/java/io/sentry/SentryInstallerLifecycleParticipant.java
+++ b/src/main/java/io/sentry/SentryInstallerLifecycleParticipant.java
@@ -93,6 +93,14 @@ public class SentryInstallerLifecycleParticipant extends AbstractMavenLifecycleP
       final @NotNull PluginConfig pluginConfig = new ConfigParser().parseConfig(project);
       SentryTelemetryService.getInstance().start(pluginConfig, project, session, pluginManager);
 
+      if (pluginConfig.isSkipAutoInstall() && pluginConfig.isSkipValidateOpenTelemetryVersions()) {
+        logger.info(
+            "Auto Install and OpenTelemetry version check disabled for project "
+                + project.getId()
+                + ", skipping dependency resolution");
+        continue;
+      }
+
       @Nullable List<Artifact> resolvedArtifacts;
       try {
         resolvedArtifacts = resolver.resolveArtifactsForProject(project, session);

--- a/src/main/java/io/sentry/SentryInstallerLifecycleParticipant.java
+++ b/src/main/java/io/sentry/SentryInstallerLifecycleParticipant.java
@@ -93,77 +93,78 @@ public class SentryInstallerLifecycleParticipant extends AbstractMavenLifecycleP
       final @NotNull PluginConfig pluginConfig = new ConfigParser().parseConfig(project);
       SentryTelemetryService.getInstance().start(pluginConfig, project, session, pluginManager);
 
-      if (pluginConfig.isSkipAutoInstall()) {
+      @Nullable List<Artifact> resolvedArtifacts;
+      try {
+        resolvedArtifacts = resolver.resolveArtifactsForProject(project, session);
+      } catch (DependencyResolutionException e) {
+        logger.error("Unable to resolve all dependencies", e);
+        continue;
+      }
+
+      if (!pluginConfig.isSkipAutoInstall()) {
+        final @Nullable ISpan span = SentryTelemetryService.getInstance().startTask("auto-install");
+
+        try {
+          final @NotNull Model currModel = project.getModel();
+
+          final @NotNull List<Dependency> dependencyList = currModel.getDependencies();
+          final @Nullable String managedSentryVersion =
+              ManagedSentryVersionResolver.getManagedSentryVersion(project);
+          final @Nullable String sentryVersion =
+              new SentryInstaller()
+                  .install(dependencyList, resolvedArtifacts, managedSentryVersion);
+
+          if (sentryVersion != null) {
+            SentryTelemetryService.getInstance().addTag("SDK_VERSION", sentryVersion);
+
+            final @NotNull AutoInstallState autoInstallState = new AutoInstallState(sentryVersion);
+            autoInstallState.setInstallSpring(shouldInstallSpring(resolvedArtifacts));
+            autoInstallState.setInstallLogback(
+                !isModuleAvailable(resolvedArtifacts, SENTRY_LOGBACK_ID));
+            autoInstallState.setInstallLog4j2(
+                !isModuleAvailable(resolvedArtifacts, SENTRY_LOG4J2_ID));
+            autoInstallState.setInstallGraphql(shouldInstallGraphQL(resolvedArtifacts));
+            autoInstallState.setInstallJdbc(!isModuleAvailable(resolvedArtifacts, SENTRY_JDBC_ID));
+            autoInstallState.setInstallQuartz(
+                !isModuleAvailable(resolvedArtifacts, SENTRY_QUARTZ_ID));
+
+            for (final @NotNull Class<? extends AbstractIntegrationInstaller> installerClass :
+                installers) {
+              try {
+                final @NotNull AbstractIntegrationInstaller installer =
+                    installerClass.getDeclaredConstructor().newInstance();
+                installer.install(dependencyList, resolvedArtifacts, autoInstallState);
+              } catch (Throwable e) {
+                logger.error(
+                    "Unable to instantiate installer class: " + installerClass.getName(), e);
+              }
+            }
+          } else {
+            logger.error(
+                "No Sentry SDK Version found, cannot auto-install sentry integrations for project + "
+                    + project.getId());
+          }
+        } catch (Throwable t) {
+          SentryTelemetryService.getInstance().captureError(t, "auto-install");
+          throw t;
+        } finally {
+          SentryTelemetryService.getInstance().endTask(span);
+        }
+      } else {
         logger.info(
             "Auto Install disabled for project "
                 + project.getId()
                 + " , not installing dependencies");
-        continue;
       }
 
-      final @Nullable ISpan span = SentryTelemetryService.getInstance().startTask("auto-install");
-
-      try {
-        @Nullable List<Artifact> resolvedArtifacts;
-        try {
-          resolvedArtifacts = resolver.resolveArtifactsForProject(project, session);
-        } catch (DependencyResolutionException e) {
-          logger.error("Unable to resolve all dependencies", e);
-          continue;
-        }
-
-        final @NotNull Model currModel = project.getModel();
-
-        final @NotNull List<Dependency> dependencyList = currModel.getDependencies();
-        final @Nullable String managedSentryVersion =
-            ManagedSentryVersionResolver.getManagedSentryVersion(project);
-        final @Nullable String sentryVersion =
-            new SentryInstaller().install(dependencyList, resolvedArtifacts, managedSentryVersion);
-
-        if (sentryVersion == null) {
-          logger.error(
-              "No Sentry SDK Version found, cannot auto-install sentry integrations for project + "
-                  + project.getId());
-          continue;
-        }
-
-        SentryTelemetryService.getInstance().addTag("SDK_VERSION", sentryVersion);
-
-        final @NotNull AutoInstallState autoInstallState = new AutoInstallState(sentryVersion);
-        autoInstallState.setInstallSpring(shouldInstallSpring(resolvedArtifacts));
-        autoInstallState.setInstallLogback(
-            !isModuleAvailable(resolvedArtifacts, SENTRY_LOGBACK_ID));
-        autoInstallState.setInstallLog4j2(!isModuleAvailable(resolvedArtifacts, SENTRY_LOG4J2_ID));
-        autoInstallState.setInstallGraphql(shouldInstallGraphQL(resolvedArtifacts));
-        autoInstallState.setInstallJdbc(!isModuleAvailable(resolvedArtifacts, SENTRY_JDBC_ID));
-        autoInstallState.setInstallQuartz(!isModuleAvailable(resolvedArtifacts, SENTRY_QUARTZ_ID));
-
-        for (final @NotNull Class<? extends AbstractIntegrationInstaller> installerClass :
-            installers) {
-          try {
-            final @NotNull AbstractIntegrationInstaller installer =
-                installerClass.getDeclaredConstructor().newInstance();
-            installer.install(dependencyList, resolvedArtifacts, autoInstallState);
-          } catch (Throwable e) {
-            logger.error("Unable to instantiate installer class: " + installerClass.getName(), e);
-          }
-        }
-
-        if (!pluginConfig.isSkipValidateOpenTelemetryVersions()) {
-          new OpenTelemetryVersionChecker()
-              .check(
-                  project,
-                  resolvedArtifacts,
-                  sentryVersion,
-                  projectBuilder,
-                  mavenRepositorySystem,
-                  session.getProjectBuildingRequest());
-        }
-      } catch (Throwable t) {
-        SentryTelemetryService.getInstance().captureError(t, "auto-install");
-        throw t;
-      } finally {
-        SentryTelemetryService.getInstance().endTask(span);
+      if (!pluginConfig.isSkipValidateOpenTelemetryVersions()) {
+        new OpenTelemetryVersionChecker()
+            .check(
+                project,
+                resolvedArtifacts,
+                projectBuilder,
+                mavenRepositorySystem,
+                session.getProjectBuildingRequest());
       }
     }
     super.afterProjectsRead(session);

--- a/src/main/java/io/sentry/autoinstall/opentelemetry/OpenTelemetryVersionChecker.java
+++ b/src/main/java/io/sentry/autoinstall/opentelemetry/OpenTelemetryVersionChecker.java
@@ -42,7 +42,7 @@ public class OpenTelemetryVersionChecker {
   static final @NotNull String SENTRY_OPENTELEMETRY_ARTIFACT_PREFIX = "sentry-opentelemetry-";
   static final @NotNull String SPRING_BOOT_GROUP_ID = "org.springframework.boot";
   static final @NotNull String DOCS_URL =
-      "https://docs.sentry.io/platforms/java/tracing/instrumentation/opentelemetry/troubleshooting/";
+      "https://docs.sentry.io/platforms/java/opentelemetry/troubleshooting/";
 
   private final @NotNull Logger logger;
 

--- a/src/main/java/io/sentry/autoinstall/opentelemetry/OpenTelemetryVersionChecker.java
+++ b/src/main/java/io/sentry/autoinstall/opentelemetry/OpenTelemetryVersionChecker.java
@@ -1,0 +1,296 @@
+package io.sentry.autoinstall.opentelemetry;
+
+import static io.sentry.Constants.SENTRY_GROUP_ID;
+import static io.sentry.Constants.SENTRY_OPENTELEMETRY_BOM_ARTIFACT_ID;
+
+import io.sentry.semver.Version;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.maven.MavenExecutionException;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.repository.RepositorySystem;
+import org.eclipse.aether.artifact.Artifact;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Fails the build when the OpenTelemetry versions resolved for a project are downgraded below the
+ * versions Sentry's {@code sentry-opentelemetry-*} artifacts were built and tested against.
+ *
+ * <p>Sentry's OpenTelemetry artifacts declare the exact OpenTelemetry versions they require. When
+ * another dependency management mechanism (most commonly Spring Boot) forces a lower OpenTelemetry
+ * version — which happens silently, without the user declaring any OpenTelemetry version — running
+ * against the mismatched versions can throw {@code ClassNotFoundException} / {@code
+ * NoSuchMethodError} at runtime. This surfaces the problem at build time with actionable guidance
+ * (import {@code sentry-opentelemetry-bom}) instead of letting it fail at runtime.
+ *
+ * <p>Only OpenTelemetry modules that a {@code sentry-opentelemetry-*} artifact actually requires
+ * are inspected, so unrelated OpenTelemetry usage is never flagged.
+ */
+public class OpenTelemetryVersionChecker {
+
+  static final @NotNull String OPENTELEMETRY_GROUP_ID = "io.opentelemetry";
+  static final @NotNull String SENTRY_OPENTELEMETRY_ARTIFACT_PREFIX = "sentry-opentelemetry-";
+  static final @NotNull String SPRING_BOOT_GROUP_ID = "org.springframework.boot";
+  static final @NotNull String DOCS_URL =
+      "https://docs.sentry.io/platforms/java/tracing/instrumentation/opentelemetry/troubleshooting/";
+
+  private final @NotNull Logger logger;
+
+  public OpenTelemetryVersionChecker() {
+    this(LoggerFactory.getLogger(OpenTelemetryVersionChecker.class));
+  }
+
+  public OpenTelemetryVersionChecker(final @NotNull Logger logger) {
+    this.logger = logger;
+  }
+
+  public void check(
+      final @NotNull MavenProject project,
+      final @NotNull List<Artifact> resolvedArtifacts,
+      final @NotNull String sentryVersion,
+      final @NotNull ProjectBuilder projectBuilder,
+      final @NotNull RepositorySystem repositorySystem,
+      final @NotNull ProjectBuildingRequest baseRequest)
+      throws MavenExecutionException {
+
+    if (!hasSentryOpenTelemetryDependency(resolvedArtifacts)) {
+      return;
+    }
+
+    final @NotNull Map<String, String> requiredVersions =
+        collectRequiredVersions(
+            project, resolvedArtifacts, projectBuilder, repositorySystem, baseRequest);
+    if (requiredVersions.isEmpty()) {
+      return;
+    }
+
+    final @NotNull Map<String, String> resolvedVersions =
+        resolvedOpenTelemetryVersions(resolvedArtifacts);
+
+    final @NotNull List<VersionMismatch> downgrades =
+        collectDowngrades(requiredVersions, resolvedVersions);
+
+    if (!downgrades.isEmpty()) {
+      throw new MavenExecutionException(
+          buildMessage(downgrades, sentryVersion, hasSpringBoot(resolvedArtifacts)),
+          project.getFile());
+    }
+  }
+
+  static boolean hasSentryOpenTelemetryDependency(final @NotNull List<Artifact> resolvedArtifacts) {
+    return resolvedArtifacts.stream().anyMatch(OpenTelemetryVersionChecker::isSentryOpenTelemetry);
+  }
+
+  private static boolean isSentryOpenTelemetry(final @NotNull Artifact artifact) {
+    return artifact.getGroupId().equals(SENTRY_GROUP_ID)
+        && artifact.getArtifactId().startsWith(SENTRY_OPENTELEMETRY_ARTIFACT_PREFIX)
+        && !artifact.getArtifactId().equals(SENTRY_OPENTELEMETRY_BOM_ARTIFACT_ID);
+  }
+
+  private static boolean isOpenTelemetryGroup(final @NotNull String groupId) {
+    return groupId.equals(OPENTELEMETRY_GROUP_ID)
+        || groupId.startsWith(OPENTELEMETRY_GROUP_ID + ".");
+  }
+
+  /**
+   * Resolves each present {@code sentry-opentelemetry-*} artifact and collects the OpenTelemetry
+   * versions it requires (from its declared dependencies and its own dependency management),
+   * keeping the highest version requested per module.
+   */
+  private @NotNull Map<String, String> collectRequiredVersions(
+      final @NotNull MavenProject project,
+      final @NotNull List<Artifact> resolvedArtifacts,
+      final @NotNull ProjectBuilder projectBuilder,
+      final @NotNull RepositorySystem repositorySystem,
+      final @NotNull ProjectBuildingRequest baseRequest) {
+    final @NotNull Map<String, String> required = new LinkedHashMap<>();
+    for (final @NotNull Artifact artifact : resolvedArtifacts) {
+      if (!isSentryOpenTelemetry(artifact)) {
+        continue;
+      }
+      try {
+        final org.apache.maven.artifact.@NotNull Artifact projectArtifact =
+            repositorySystem.createProjectArtifact(
+                artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion());
+        final @NotNull ProjectBuildingRequest request =
+            new DefaultProjectBuildingRequest(baseRequest);
+        request.setProject(null);
+        request.setResolveDependencies(false);
+        request.setRemoteRepositories(project.getRemoteArtifactRepositories());
+        request.setValidationLevel(
+            org.apache.maven.model.building.ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL);
+
+        final @NotNull MavenProject artifactProject =
+            projectBuilder.build(projectArtifact, true, request).getProject();
+
+        mergeOpenTelemetryVersions(artifactProject.getDependencies(), required);
+        final @Nullable DependencyManagement dependencyManagement =
+            artifactProject.getDependencyManagement();
+        if (dependencyManagement != null) {
+          mergeOpenTelemetryVersions(dependencyManagement.getDependencies(), required);
+        }
+      } catch (Throwable t) {
+        logger.info(
+            "Unable to resolve "
+                + artifact.getArtifactId()
+                + " to verify OpenTelemetry versions: "
+                + t.getMessage());
+      }
+    }
+    return required;
+  }
+
+  private void mergeOpenTelemetryVersions(
+      final @NotNull List<Dependency> dependencies, final @NotNull Map<String, String> target) {
+    for (final @NotNull Dependency dependency : dependencies) {
+      if (!isOpenTelemetryGroup(dependency.getGroupId()) || dependency.getVersion() == null) {
+        continue;
+      }
+      final @NotNull String key = key(dependency.getGroupId(), dependency.getArtifactId());
+      final @Nullable String existing = target.get(key);
+      if (existing == null || isHigher(dependency.getVersion(), existing)) {
+        target.put(key, dependency.getVersion());
+      }
+    }
+  }
+
+  private @NotNull Map<String, String> resolvedOpenTelemetryVersions(
+      final @NotNull List<Artifact> resolvedArtifacts) {
+    final @NotNull Map<String, String> resolved = new LinkedHashMap<>();
+    for (final @NotNull Artifact artifact : resolvedArtifacts) {
+      if (isOpenTelemetryGroup(artifact.getGroupId())) {
+        resolved.put(key(artifact.getGroupId(), artifact.getArtifactId()), artifact.getVersion());
+      }
+    }
+    return resolved;
+  }
+
+  static @NotNull List<VersionMismatch> collectDowngrades(
+      final @NotNull Map<String, String> requiredVersions,
+      final @NotNull Map<String, String> resolvedVersions) {
+    final @NotNull List<VersionMismatch> downgrades = new ArrayList<>();
+    for (final Map.@NotNull Entry<String, String> entry : requiredVersions.entrySet()) {
+      final @Nullable String resolved = resolvedVersions.get(entry.getKey());
+      if (resolved != null && isDowngrade(entry.getValue(), resolved)) {
+        downgrades.add(new VersionMismatch(entry.getKey(), entry.getValue(), resolved));
+      }
+    }
+    return downgrades;
+  }
+
+  private static boolean isDowngrade(
+      final @NotNull String required, final @NotNull String resolved) {
+    if (required.equals(resolved)) {
+      return false;
+    }
+    try {
+      return Version.parseVersion(resolved).isLowerThan(Version.parseVersion(required));
+    } catch (RuntimeException e) {
+      // versions that can't be parsed as semver can't be compared reliably; don't flag them
+      return false;
+    }
+  }
+
+  private static boolean isHigher(final @NotNull String candidate, final @NotNull String existing) {
+    try {
+      return Version.parseVersion(candidate).isGreaterThan(Version.parseVersion(existing));
+    } catch (RuntimeException e) {
+      return false;
+    }
+  }
+
+  private static boolean hasSpringBoot(final @NotNull List<Artifact> resolvedArtifacts) {
+    return resolvedArtifacts.stream()
+        .anyMatch((artifact) -> artifact.getGroupId().startsWith(SPRING_BOOT_GROUP_ID));
+  }
+
+  static @NotNull String buildMessage(
+      final @NotNull List<VersionMismatch> downgrades,
+      final @NotNull String sentryVersion,
+      final boolean springBoot) {
+    final @NotNull StringBuilder details = new StringBuilder();
+    for (final @NotNull VersionMismatch mismatch : downgrades) {
+      details
+          .append("  - ")
+          .append(mismatch.module)
+          .append(": Sentry requires ")
+          .append(mismatch.required)
+          .append(" but ")
+          .append(mismatch.resolved)
+          .append(" was resolved\n");
+    }
+
+    final @NotNull String ordering =
+        springBoot
+            ? "In Maven the first matching <dependencyManagement> entry wins, so declare "
+                + SENTRY_OPENTELEMETRY_BOM_ARTIFACT_ID
+                + " before spring-boot-dependencies (or in your child POM, which takes "
+                + "precedence over a parent POM's dependency management).\n\n"
+            : "";
+
+    return "Sentry detected that OpenTelemetry was downgraded below the version its integration "
+        + "requires.\n\n"
+        + "The Sentry OpenTelemetry integration was built against specific OpenTelemetry versions, "
+        + "but the following were downgraded by another dependency management mechanism:\n\n"
+        + details
+        + "\nRunning with these downgraded OpenTelemetry versions can cause "
+        + "ClassNotFoundException / NoSuchMethodError at runtime.\n\n"
+        + "To fix this, import the Sentry OpenTelemetry BOM in your <dependencyManagement> so its "
+        + "versions win dependency resolution:\n\n"
+        + ordering
+        + "  <dependencyManagement>\n"
+        + "    <dependencies>\n"
+        + "      <dependency>\n"
+        + "        <groupId>"
+        + SENTRY_GROUP_ID
+        + "</groupId>\n"
+        + "        <artifactId>"
+        + SENTRY_OPENTELEMETRY_BOM_ARTIFACT_ID
+        + "</artifactId>\n"
+        + "        <version>"
+        + sentryVersion
+        + "</version>\n"
+        + "        <type>pom</type>\n"
+        + "        <scope>import</scope>\n"
+        + "      </dependency>\n"
+        + "    </dependencies>\n"
+        + "  </dependencyManagement>\n\n"
+        + "See "
+        + DOCS_URL
+        + " for details.\n\n"
+        + "You can disable this check by setting "
+        + "<skipValidateOpenTelemetryVersions>true</skipValidateOpenTelemetryVersions> in the "
+        + SENTRY_GROUP_ID
+        + " plugin configuration.";
+  }
+
+  private static @NotNull String key(
+      final @NotNull String groupId, final @NotNull String artifactId) {
+    return groupId + ":" + artifactId;
+  }
+
+  static class VersionMismatch {
+    final @NotNull String module;
+    final @NotNull String required;
+    final @NotNull String resolved;
+
+    VersionMismatch(
+        final @NotNull String module,
+        final @NotNull String required,
+        final @NotNull String resolved) {
+      this.module = module;
+      this.required = required;
+      this.resolved = resolved;
+    }
+  }
+}

--- a/src/main/java/io/sentry/autoinstall/opentelemetry/OpenTelemetryVersionChecker.java
+++ b/src/main/java/io/sentry/autoinstall/opentelemetry/OpenTelemetryVersionChecker.java
@@ -57,7 +57,6 @@ public class OpenTelemetryVersionChecker {
   public void check(
       final @NotNull MavenProject project,
       final @NotNull List<Artifact> resolvedArtifacts,
-      final @NotNull String sentryVersion,
       final @NotNull ProjectBuilder projectBuilder,
       final @NotNull RepositorySystem repositorySystem,
       final @NotNull ProjectBuildingRequest baseRequest)
@@ -81,6 +80,7 @@ public class OpenTelemetryVersionChecker {
         collectDowngrades(requiredVersions, resolvedVersions);
 
     if (!downgrades.isEmpty()) {
+      final @NotNull String sentryVersion = findSentryOpenTelemetryVersion(resolvedArtifacts);
       throw new MavenExecutionException(
           buildMessage(downgrades, sentryVersion, hasSpringBoot(resolvedArtifacts)),
           project.getFile());
@@ -95,6 +95,15 @@ public class OpenTelemetryVersionChecker {
     return artifact.getGroupId().equals(SENTRY_GROUP_ID)
         && artifact.getArtifactId().startsWith(SENTRY_OPENTELEMETRY_ARTIFACT_PREFIX)
         && !artifact.getArtifactId().equals(SENTRY_OPENTELEMETRY_BOM_ARTIFACT_ID);
+  }
+
+  private static @NotNull String findSentryOpenTelemetryVersion(
+      final @NotNull List<Artifact> resolvedArtifacts) {
+    return resolvedArtifacts.stream()
+        .filter(OpenTelemetryVersionChecker::isSentryOpenTelemetry)
+        .map(Artifact::getVersion)
+        .findFirst()
+        .orElse("UNKNOWN");
   }
 
   private static boolean isOpenTelemetryGroup(final @NotNull String groupId) {

--- a/src/main/java/io/sentry/config/ConfigParser.java
+++ b/src/main/java/io/sentry/config/ConfigParser.java
@@ -15,6 +15,8 @@ public class ConfigParser {
 
   private static final @NotNull String SKIP_ALL_FLAG = "skip";
   private static final @NotNull String SKIP_AUTO_INSTALL_FLAG = "skipAutoInstall";
+  private static final @NotNull String SKIP_VALIDATE_OPENTELEMETRY_VERSIONS_FLAG =
+      "skipValidateOpenTelemetryVersions";
   private static final @NotNull String SKIP_TELEMETRY_FLAG = "skipTelemetry";
   private static final @NotNull String SKIP_REPORT_DEPENDENCIES_FLAG = "skipReportDependencies";
   private static final @NotNull String SKIP_SOURCE_BUNDLE_FLAG = "skipSourceBundle";
@@ -55,6 +57,11 @@ public class ConfigParser {
       pluginConfig.setSkipAutoInstall(
           dom.getChild(SKIP_AUTO_INSTALL_FLAG) != null
               && Boolean.parseBoolean(dom.getChild(SKIP_AUTO_INSTALL_FLAG).getValue()));
+
+      pluginConfig.setSkipValidateOpenTelemetryVersions(
+          dom.getChild(SKIP_VALIDATE_OPENTELEMETRY_VERSIONS_FLAG) != null
+              && Boolean.parseBoolean(
+                  dom.getChild(SKIP_VALIDATE_OPENTELEMETRY_VERSIONS_FLAG).getValue()));
 
       pluginConfig.setSkipTelemetry(
           dom.getChild(SKIP_TELEMETRY_FLAG) != null

--- a/src/main/java/io/sentry/config/PluginConfig.java
+++ b/src/main/java/io/sentry/config/PluginConfig.java
@@ -10,6 +10,8 @@ public class PluginConfig {
   public static final @NotNull String DEFAULT_SKIP_REPORT_DEPENDENCIES_STRING = "false";
   public static final boolean DEFAULT_SKIP_AUTO_INSTALL = false;
   public static final @NotNull String DEFAULT_SKIP_AUTO_INSTALL_STRING = "false";
+  public static final boolean DEFAULT_SKIP_VALIDATE_OPENTELEMETRY_VERSIONS = false;
+  public static final @NotNull String DEFAULT_SKIP_VALIDATE_OPENTELEMETRY_VERSIONS_STRING = "false";
   public static final boolean DEFAULT_SKIP_SOURCE_BUNDLE = false;
   public static final @NotNull String DEFAULT_SKIP_SOURCE_BUNDLE_STRING = "false";
   public static final boolean DEFAULT_IGNORE_SOURCE_BUNDLE_UPLOAD_FAILURE = false;
@@ -27,6 +29,7 @@ public class PluginConfig {
 
   private boolean skip = DEFAULT_SKIP;
   private boolean skipAutoInstall = DEFAULT_SKIP_AUTO_INSTALL;
+  private boolean skipValidateOpenTelemetryVersions = DEFAULT_SKIP_VALIDATE_OPENTELEMETRY_VERSIONS;
   private boolean skipTelemetry = DEFAULT_SKIP_TELEMETRY;
   private boolean skipReportDependencies = DEFAULT_SKIP_REPORT_DEPENDENCIES;
   private boolean skipSourceBundle = DEFAULT_SKIP_SOURCE_BUNDLE;
@@ -102,6 +105,15 @@ public class PluginConfig {
 
   public boolean isSkipAutoInstall() {
     return skipAutoInstall || skip;
+  }
+
+  public void setSkipValidateOpenTelemetryVersions(
+      final boolean skipValidateOpenTelemetryVersions) {
+    this.skipValidateOpenTelemetryVersions = skipValidateOpenTelemetryVersions;
+  }
+
+  public boolean isSkipValidateOpenTelemetryVersions() {
+    return skipValidateOpenTelemetryVersions || skip;
   }
 
   public boolean isSkipTelemetry() {

--- a/src/main/java/io/sentry/telemetry/SentryTelemetryService.java
+++ b/src/main/java/io/sentry/telemetry/SentryTelemetryService.java
@@ -103,6 +103,9 @@ public class SentryTelemetryService {
                   "SENTRY_autoInstallation_enabled",
                   String.valueOf(!pluginConfig.isSkipAutoInstall()));
               options.setTag(
+                  "SENTRY_validateOpenTelemetryVersions",
+                  String.valueOf(!pluginConfig.isSkipValidateOpenTelemetryVersions()));
+              options.setTag(
                   "SENTRY_includeDependenciesReport",
                   String.valueOf(!pluginConfig.isSkipReportDependencies()));
               options.setTag(

--- a/src/test/java/io/sentry/autoinstall/opentelemetry/OpenTelemetryVersionCheckerTest.kt
+++ b/src/test/java/io/sentry/autoinstall/opentelemetry/OpenTelemetryVersionCheckerTest.kt
@@ -1,0 +1,138 @@
+package io.sentry.autoinstall.opentelemetry
+
+import org.eclipse.aether.artifact.Artifact
+import org.eclipse.aether.artifact.DefaultArtifact
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class OpenTelemetryVersionCheckerTest {
+    private fun artifact(
+        groupId: String,
+        artifactId: String,
+        version: String,
+    ): Artifact = DefaultArtifact(groupId, artifactId, null, version)
+
+    @Test
+    fun `flags a downgraded opentelemetry module`() {
+        val downgrades =
+            OpenTelemetryVersionChecker.collectDowngrades(
+                mapOf("io.opentelemetry:opentelemetry-sdk" to "1.57.0"),
+                mapOf("io.opentelemetry:opentelemetry-sdk" to "1.43.0"),
+            )
+
+        assertEquals(1, downgrades.size)
+        assertEquals("io.opentelemetry:opentelemetry-sdk", downgrades[0].module)
+        assertEquals("1.57.0", downgrades[0].required)
+        assertEquals("1.43.0", downgrades[0].resolved)
+    }
+
+    @Test
+    fun `does not flag matching versions`() {
+        val downgrades =
+            OpenTelemetryVersionChecker.collectDowngrades(
+                mapOf("io.opentelemetry:opentelemetry-sdk" to "1.57.0"),
+                mapOf("io.opentelemetry:opentelemetry-sdk" to "1.57.0"),
+            )
+        assertTrue { downgrades.isEmpty() }
+    }
+
+    @Test
+    fun `does not flag upgrades`() {
+        val downgrades =
+            OpenTelemetryVersionChecker.collectDowngrades(
+                mapOf("io.opentelemetry:opentelemetry-sdk" to "1.57.0"),
+                mapOf("io.opentelemetry:opentelemetry-sdk" to "1.60.0"),
+            )
+        assertTrue { downgrades.isEmpty() }
+    }
+
+    @Test
+    fun `ignores modules that are not resolved in the project`() {
+        val downgrades =
+            OpenTelemetryVersionChecker.collectDowngrades(
+                mapOf("io.opentelemetry:opentelemetry-exporter-zipkin" to "1.57.0"),
+                mapOf("io.opentelemetry:opentelemetry-sdk" to "1.43.0"),
+            )
+        assertTrue { downgrades.isEmpty() }
+    }
+
+    @Test
+    fun `flags downgraded alpha versions`() {
+        val downgrades =
+            OpenTelemetryVersionChecker.collectDowngrades(
+                mapOf("io.opentelemetry:opentelemetry-semconv-incubating" to "1.37.0-alpha"),
+                mapOf("io.opentelemetry:opentelemetry-semconv-incubating" to "1.36.0-alpha"),
+            )
+        assertEquals(1, downgrades.size)
+    }
+
+    @Test
+    fun `does not flag unparseable versions`() {
+        val downgrades =
+            OpenTelemetryVersionChecker.collectDowngrades(
+                mapOf("io.opentelemetry:opentelemetry-sdk" to "1.57.0"),
+                mapOf("io.opentelemetry:opentelemetry-sdk" to "weird-version"),
+            )
+        assertTrue { downgrades.isEmpty() }
+    }
+
+    @Test
+    fun `detects an eligible sentry opentelemetry dependency`() {
+        assertTrue {
+            OpenTelemetryVersionChecker.hasSentryOpenTelemetryDependency(
+                listOf(artifact("io.sentry", "sentry-opentelemetry-agentless", "8.34.1")),
+            )
+        }
+        assertFalse {
+            OpenTelemetryVersionChecker.hasSentryOpenTelemetryDependency(
+                listOf(artifact("io.sentry", "sentry-opentelemetry-bom", "8.34.1")),
+            )
+        }
+        assertFalse {
+            OpenTelemetryVersionChecker.hasSentryOpenTelemetryDependency(
+                listOf(artifact("io.sentry", "sentry", "8.34.1")),
+            )
+        }
+    }
+
+    @Test
+    fun `message includes the mismatch, the bom snippet and the opt-out`() {
+        val message =
+            OpenTelemetryVersionChecker.buildMessage(
+                listOf(
+                    OpenTelemetryVersionChecker.VersionMismatch(
+                        "io.opentelemetry:opentelemetry-sdk",
+                        "1.57.0",
+                        "1.43.0",
+                    ),
+                ),
+                "8.34.1",
+                false,
+            )
+
+        assertTrue { message.contains("io.opentelemetry:opentelemetry-sdk: Sentry requires 1.57.0 but 1.43.0 was resolved") }
+        assertTrue { message.contains("<artifactId>sentry-opentelemetry-bom</artifactId>") }
+        assertTrue { message.contains("<version>8.34.1</version>") }
+        assertTrue { message.contains("skipValidateOpenTelemetryVersions") }
+    }
+
+    @Test
+    fun `message mentions ordering when spring boot is present`() {
+        val message =
+            OpenTelemetryVersionChecker.buildMessage(
+                listOf(
+                    OpenTelemetryVersionChecker.VersionMismatch(
+                        "io.opentelemetry:opentelemetry-sdk",
+                        "1.57.0",
+                        "1.43.0",
+                    ),
+                ),
+                "8.34.1",
+                true,
+            )
+
+        assertTrue { message.contains("before spring-boot-dependencies") }
+    }
+}

--- a/src/test/java/io/sentry/integration/autoinstall/SentryAutoInstallTestIT.kt
+++ b/src/test/java/io/sentry/integration/autoinstall/SentryAutoInstallTestIT.kt
@@ -102,7 +102,7 @@ class SentryAutoInstallTestIT {
         verifier.isAutoclean = false
         verifier.executeGoal("install")
         verifier.verifyFileNotPresent("target/lib/sentry-${SdkVersionInfo.getSentryVersion()}.jar")
-        verifier.verifyTextInLog("Auto Install disabled for project ")
+        verifier.verifyTextInLog("Auto Install and OpenTelemetry version check disabled for project ")
         verifier.resetStreams()
     }
 

--- a/src/test/java/io/sentry/integration/autoinstall/opentelemetry/OpenTelemetryVersionCheckTestIT.kt
+++ b/src/test/java/io/sentry/integration/autoinstall/opentelemetry/OpenTelemetryVersionCheckTestIT.kt
@@ -76,6 +76,28 @@ class OpenTelemetryVersionCheckTestIT {
     }
 
     @Test
+    fun `fails the build when OpenTelemetry is downgraded even with auto-install disabled`() {
+        val verifier =
+            writePom(
+                openTelemetryPom(
+                    sentryVersion = sentryVersion,
+                    useSpringBootParent = true,
+                    pluginConfiguration =
+                        """
+                        <configuration>
+                            <skipAutoInstall>true</skipAutoInstall>
+                        </configuration>
+                        """.trimIndent(),
+                ),
+            )
+
+        assertFailsWith<VerificationException> { verifier.executeGoal("validate") }
+
+        verifier.verifyTextInLog("Sentry detected that OpenTelemetry was downgraded")
+        verifier.resetStreams()
+    }
+
+    @Test
     fun `does nothing without a sentry opentelemetry dependency`() {
         val verifier =
             writePom(

--- a/src/test/java/io/sentry/integration/autoinstall/opentelemetry/OpenTelemetryVersionCheckTestIT.kt
+++ b/src/test/java/io/sentry/integration/autoinstall/opentelemetry/OpenTelemetryVersionCheckTestIT.kt
@@ -1,0 +1,93 @@
+package io.sentry.integration.autoinstall.opentelemetry
+
+import io.sentry.autoinstall.util.SdkVersionInfo
+import io.sentry.integration.installMavenWrapper
+import org.apache.maven.it.VerificationException
+import org.apache.maven.it.Verifier
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.StandardOpenOption
+import kotlin.io.path.Path
+import kotlin.test.assertFailsWith
+
+class OpenTelemetryVersionCheckTestIT {
+    @TempDir
+    lateinit var file: File
+
+    private val sentryVersion: String = SdkVersionInfo.getSentryVersion()!!
+
+    @BeforeEach
+    fun setup() {
+        installMavenWrapper(file, "3.8.6")
+    }
+
+    private fun writePom(content: String): Verifier {
+        Files.write(Path("${file.absolutePath}/pom.xml"), content.toByteArray(), StandardOpenOption.CREATE)
+        return Verifier(file.absolutePath).apply { isAutoclean = false }
+    }
+
+    @Test
+    fun `fails the build when OpenTelemetry is downgraded by spring boot`() {
+        val verifier =
+            writePom(
+                openTelemetryPom(sentryVersion = sentryVersion, useSpringBootParent = true),
+            )
+
+        assertFailsWith<VerificationException> { verifier.executeGoal("validate") }
+
+        verifier.verifyTextInLog("Sentry detected that OpenTelemetry was downgraded")
+        verifier.verifyTextInLog("io.opentelemetry:opentelemetry-sdk")
+        verifier.verifyTextInLog("<artifactId>sentry-opentelemetry-bom</artifactId>")
+        verifier.resetStreams()
+    }
+
+    @Test
+    fun `succeeds when OpenTelemetry versions are not downgraded`() {
+        val verifier =
+            writePom(openTelemetryPom(sentryVersion = sentryVersion))
+
+        verifier.executeGoal("validate")
+
+        verifier.resetStreams()
+    }
+
+    @Test
+    fun `does not fail when the check is disabled`() {
+        val verifier =
+            writePom(
+                openTelemetryPom(
+                    sentryVersion = sentryVersion,
+                    useSpringBootParent = true,
+                    pluginConfiguration =
+                        """
+                        <configuration>
+                            <skipValidateOpenTelemetryVersions>true</skipValidateOpenTelemetryVersions>
+                        </configuration>
+                        """.trimIndent(),
+                ),
+            )
+
+        verifier.executeGoal("validate")
+
+        verifier.resetStreams()
+    }
+
+    @Test
+    fun `does nothing without a sentry opentelemetry dependency`() {
+        val verifier =
+            writePom(
+                openTelemetryPom(
+                    sentryVersion = sentryVersion,
+                    useSpringBootParent = true,
+                    otelDependency = "sentry",
+                ),
+            )
+
+        verifier.executeGoal("validate")
+
+        verifier.resetStreams()
+    }
+}

--- a/src/test/java/io/sentry/integration/autoinstall/opentelemetry/PomUtils.kt
+++ b/src/test/java/io/sentry/integration/autoinstall/opentelemetry/PomUtils.kt
@@ -1,0 +1,70 @@
+package io.sentry.integration.autoinstall.opentelemetry
+
+/**
+ * Builds a POM for the OpenTelemetry version-check integration tests.
+ *
+ * @param sentryVersion version used for the Sentry OpenTelemetry dependency
+ * @param useSpringBootParent inherit OpenTelemetry version management (which downgrades OTel) from
+ *   spring-boot-starter-parent
+ * @param otelDependency the Sentry dependency to declare (agentless by default; use `sentry` to
+ *   exercise the no-OpenTelemetry case)
+ * @param pluginConfiguration optional `<configuration>` block for the Sentry plugin
+ */
+fun openTelemetryPom(
+    sentryVersion: String,
+    useSpringBootParent: Boolean = false,
+    otelDependency: String = "sentry-opentelemetry-agentless",
+    pluginConfiguration: String = "",
+): String {
+    val parent =
+        if (useSpringBootParent) {
+            """
+            <parent>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-parent</artifactId>
+                <version>3.4.1</version>
+                <relativePath/>
+            </parent>
+            """.trimIndent()
+        } else {
+            ""
+        }
+
+    return """
+        <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+            <modelVersion>4.0.0</modelVersion>
+            $parent
+            <groupId>io.sentry.autoinstall</groupId>
+            <artifactId>verifyotel</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <packaging>jar</packaging>
+
+            <properties>
+                <maven.compiler.source>17</maven.compiler.source>
+                <maven.compiler.target>17</maven.compiler.target>
+                <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+            </properties>
+
+            <dependencies>
+                <dependency>
+                    <groupId>io.sentry</groupId>
+                    <artifactId>$otelDependency</artifactId>
+                    <version>$sentryVersion</version>
+                </dependency>
+            </dependencies>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.sentry</groupId>
+                        <artifactId>sentry-maven-plugin</artifactId>
+                        <version>1.0-SNAPSHOT</version>
+                        <extensions>true</extensions>
+                        $pluginConfiguration
+                    </plugin>
+                </plugins>
+            </build>
+        </project>
+        """.trimIndent()
+}


### PR DESCRIPTION
Builds on top of #265. Maven port of getsentry/sentry-android-gradle-plugin#1350 (which itself is stacked on the SAGP equivalent of #265, getsentry/sentry-android-gradle-plugin#1349).

## What

Fails the build when the OpenTelemetry versions resolved for a project are **downgraded** below what Sentry's `sentry-opentelemetry-*` artifacts were built and tested against.

## Why

Sentry's OpenTelemetry artifacts declare the exact OpenTelemetry versions they require. When another dependency management mechanism — most commonly Spring Boot (via `spring-boot-starter-parent` or an imported `spring-boot-dependencies` BOM) — forces OpenTelemetry below those versions, it happens **silently** (the user never declares an OTel version). Running against the mismatched versions can throw `ClassNotFoundException` / `NoSuchMethodError` at runtime. This surfaces the problem at build time with actionable guidance instead.

This **replaces an earlier approach that auto-installed the BOM** (previous PR #266). In Maven a late-injected import-scope BOM is a no-op (BOM imports are flattened during effective-model building, before `afterProjectsRead`), and rewriting inherited `dependencyManagement` in place is too surprising. Detecting-and-failing is the more honest behavior — same conclusion as SAGP #1350.

## How it works

- Runs in the lifecycle participant (automatic, no execution config needed), reusing the dependency resolution already done for auto-install.
- Gated by a cheap check: skipped entirely unless the project uses a `sentry-opentelemetry-*` artifact.
- Resolves each present `sentry-opentelemetry-*` artifact to determine the OpenTelemetry versions it requires (declared dependencies + its own dependency management), then compares against the versions actually resolved on the project. A resolved version lower than the required version is a downgrade.
- Only OpenTelemetry modules a `sentry-opentelemetry-*` artifact requires are inspected, so unrelated OpenTelemetry usage is never flagged. Unparseable versions are skipped.
- The failure message lists each downgrade and shows the exact `<dependencyManagement>` import for `sentry-opentelemetry-bom` at the resolved Sentry version, noting Maven's first-declaration-wins ordering when Spring Boot is present.

## Config

Opt out with `<skipValidateOpenTelemetryVersions>true</skipValidateOpenTelemetryVersions>`. Adds a `SENTRY_validateOpenTelemetryVersions` telemetry tag.

## Phase / placement

Implemented in the lifecycle participant (runs before any phase, automatically) rather than as an opt-in `validate`-phase mojo, so users get protected by default — matching SAGP #1350's automatic, default-on behavior.

## Open items (mirroring SAGP #1350)

- **Docs URL is a placeholder** (`.../platforms/java/tracing/instrumentation/opentelemetry/troubleshooting/`) and must resolve to a live page before release.
- **Default-on is a product call.** Defaulting a build-breaking check to on will surprise existing Spring Boot users on upgrade. Either keep default-on with a clearly-flagged behavioral-change changelog entry, or ship opt-in first and flip later based on telemetry.

## Tests

- Unit (`OpenTelemetryVersionCheckerTest`): downgrade detection (match / upgrade / not-resolved / alpha / unparseable), eligibility gate, and failure-message content (mismatch line, BOM snippet, opt-out, Spring Boot ordering note).
- Integration (`OpenTelemetryVersionCheckTestIT`): build fails on a Spring Boot parent downgrade with the guidance message; succeeds when not downgraded; succeeds when disabled; no-op without a Sentry OpenTelemetry dependency.

Co-authored with Claude.
